### PR TITLE
Add support for EKS platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+# aws-terraform-ec2_asg
+
+This module creates one or more autoscaling groups.
+
+## Basic Usage
+
+```
+module "asg" {
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.0.2"
+
+ ec2_os              = "amazon"
+ subnets             = ["${module.vpc.private_subnets}"]
+ image_id            = "${var.image_id}"
+ resource_name       = "my_asg"
+ security_group_list = ["${module.sg.private_web_security_group_id}"]
+}
+```
+
+Full working references are available at [examples](examples)
+
 
 ## Inputs
 
@@ -22,10 +42,13 @@
 | cw_scaling_metric | The metric to be used for scaling. | string | `CPUUtilization` | no |
 | detailed_monitoring | Enable Detailed Monitoring? true or false | string | `true` | no |
 | ec2_os | Intended Operating System/Distribution of Instance. Valid inputs are ('amazon', 'rhel6', 'rhel7', 'centos6', 'centos7', 'ubuntu14', 'ubuntu16', 'windows') | string | - | yes |
-| ec2_scale_down_adjustment | Number of EC2 instances to scale down by at a time. | string | `1` | no |
+| ec2_scale_down_adjustment | Number of EC2 instances to scale down by at a time. | string | `-1` | no |
 | ec2_scale_down_cool_down | Time in seconds before any further trigger-related scaling can occur. | string | `60` | no |
 | ec2_scale_up_adjustment | Number of EC2 instances to scale up by at a time. | string | `1` | no |
 | ec2_scale_up_cool_down | Time in seconds before any further trigger-related scaling can occur. | string | `60` | no |
+| ecs_cluster_name | The name of the ECS cluster to pass into the userdata script. This could be combined with the output of the aws-terraform-ecs module. Only used if the selected OS is either amazoneks or amazonecs. | string | `` | no |
+| eks_bootstrap_arguments | Any optional parameters for the EKS Bootstrapping script. This is ignored for all os's except amazon EKS | string | `` | no |
+| eks_cluster_name | The name of the EKS cluster to pass into the userdata script. This is ignored for all os's except amazon EKS | string | `` | no |
 | enable_ebs_optimization | Use EBS Optimized? true or false | string | `false` | no |
 | enable_rackspace_ticket | Specifies whether alarms will generate Rackspace tickets. true or false | string | `false` | no |
 | enable_scaling_notification | true or false. If 'scaling_notification_topic' is set to a non-empty string, this must be set to true. Otherwise, set to false. This variable exists due to a terraform limitation with using count and computed values as conditionals | string | `false` | no |
@@ -64,4 +87,5 @@
 | Name | Description |
 |------|-------------|
 | asg_name_list | List of ASG names |
+| iam_role | Name of the created IAM Instance role. |
 

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,25 @@
+/**
+ * # aws-terraform-ec2_asg
+ *
+ *This module creates one or more autoscaling groups.
+ *
+ *## Basic Usage
+ *
+ *```
+ *module "asg" {
+ *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.0.2"
+ *
+ *  ec2_os              = "amazon"
+ *  subnets             = ["${module.vpc.private_subnets}"]
+ *  image_id            = "${var.image_id}"
+ *  resource_name       = "my_asg"
+ *  security_group_list = ["${module.sg.private_web_security_group_id}"]
+ *}
+ *```
+ *
+ * Full working references are available at [examples](examples)
+ */
+
 locals {
   # This is a list of ssm main steps
   default_ssm_cmd_list = [
@@ -115,14 +137,16 @@ EOF
   ssm_command_count = 6
 
   ebs_device_map = {
-    rhel6    = "/dev/sdf"
-    rhel7    = "/dev/sdf"
-    centos6  = "/dev/sdf"
-    centos7  = "/dev/sdf"
-    windows  = "xvdf"
-    ubuntu14 = "/dev/sdf"
-    ubuntu16 = "/dev/sdf"
-    amazon   = "/dev/sdf"
+    rhel6     = "/dev/sdf"
+    rhel7     = "/dev/sdf"
+    centos6   = "/dev/sdf"
+    centos7   = "/dev/sdf"
+    windows   = "xvdf"
+    ubuntu14  = "/dev/sdf"
+    ubuntu16  = "/dev/sdf"
+    amazon    = "/dev/sdf"
+    amazoneks = "/dev/sdf"
+    amazonecs = "/dev/xvdcz"
   }
 
   cwagent_config = "${var.ec2_os != "windows" ? "linux_cw_agent_param.txt" : "windows_cw_agent_param.txt"}"
@@ -166,6 +190,7 @@ EOF
   ]
 
   ecs_setup = "${var.ecs_cluster_name != "" ? "echo ECS_Cluster=${var.ecs_cluster_name} >> /etc/ecs/ecs.config" : "" }"
+  eks_setup = "${var.eks_cluster_name != "" ? "/etc/eks/bootstrap.sh ${var.eks_cluster_name} ${var.eks_bootstrap_arguments}" : "" }"
 
   user_data_map = {
     amazon    = "amazon_linux_userdata.sh"
@@ -187,6 +212,7 @@ data "template_file" "user_data" {
 
   vars {
     ecssetup = "${local.ecs_setup}"
+    ekssetup = "${local.eks_setup}"
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,8 @@ output "asg_name_list" {
   description = "List of ASG names"
   value       = ["${aws_autoscaling_group.autoscalegrp.*.name}"]
 }
+
+output "iam_role" {
+  description = "Name of the created IAM Instance role."
+  value       = "${aws_iam_role.mod_ec2_instance_role.id}"
+}

--- a/text/amazon_linux_userdata.sh
+++ b/text/amazon_linux_userdata.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-${ecssetup}
+${ecssetup}${ekssetup}
 
 # Ensure SSM installed on Amazon Linux
 # in cases where it is not available / removed

--- a/variables.tf
+++ b/variables.tf
@@ -113,7 +113,7 @@ variable "ec2_scale_down_cool_down" {
 variable "ec2_scale_down_adjustment" {
   description = "Number of EC2 instances to scale down by at a time."
   type        = "string"
-  default     = "1"
+  default     = "-1"
 }
 
 variable "ec2_scale_up_adjustment" {
@@ -356,6 +356,18 @@ variable "terminated_instances" {
 
 variable "ecs_cluster_name" {
   description = "The name of the ECS cluster to pass into the userdata script. This could be combined with the output of the aws-terraform-ecs module. Only used if the selected OS is either amazoneks or amazonecs."
+  type        = "string"
+  default     = ""
+}
+
+variable "eks_cluster_name" {
+  description = "The name of the EKS cluster to pass into the userdata script. This is ignored for all os's except amazon EKS"
+  type        = "string"
+  default     = ""
+}
+
+variable "eks_bootstrap_arguments" {
+  description = "Any optional parameters for the EKS Bootstrapping script. This is ignored for all os's except amazon EKS"
   type        = "string"
   default     = ""
 }


### PR DESCRIPTION
Updates the ebs_device_map local variable to include Amazon ECS and EKS

Adds local variable for EKS userdata snippet and adds reference in amazon userdata template

Add variables for EKS cluster name and additional bootstrapping parameters.  Corrects default value of `ec2_scale_down_adjustment` variable.

Adds header to top of main.tf to generate README usage example and summary.

Adds IAM role name to outputs, for use by EKS module.