### PR TITLE
Add Rack-SetMOTD doc to bootstrapping

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -107,6 +107,19 @@ EOF
       {
         "action": "aws:runDocument",
         "inputs": {
+          "documentPath": "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-SetMotd",
+          "documentType": "SSMDocument"
+        },
+        "name": "SetMotd",
+        "timeoutSeconds": 300
+      }
+EOF
+    },
+    {
+      ssm_add_step = <<EOF
+      {
+        "action": "aws:runDocument",
+        "inputs": {
           "documentPath": "AWS-UpdateSSMAgent",
           "documentType": "SSMDocument"
         },


### PR DESCRIPTION
Adds the `Rasck-SetMOTD` to ASG bootstrapping, to set the default MOTD\Login Banner on those instances.

Fixes rackspace-infrastructure-automation/aws-terraform-internal#157