### PR TITLE
Add default AMI mappings and query to module

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ module "asg" {
 
 Full working references are available at [examples](examples)
 
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -41,7 +42,7 @@ Full working references are available at [examples](examples)
 | cw_low_threshold | The value against which the specified statistic is compared. | string | `30` | no |
 | cw_scaling_metric | The metric to be used for scaling. | string | `CPUUtilization` | no |
 | detailed_monitoring | Enable Detailed Monitoring? true or false | string | `true` | no |
-| ec2_os | Intended Operating System/Distribution of Instance. Valid inputs are ('amazon', 'rhel6', 'rhel7', 'centos6', 'centos7', 'ubuntu14', 'ubuntu16', 'windows') | string | - | yes |
+| ec2_os | Intended Operating System/Distribution of Instance. Valid inputs are ('amazon', 'rhel6', 'rhel7', 'centos6', 'centos7', 'ubuntu14', 'ubuntu16', 'windows2008', 'windows2012R2', 'windows2016') | string | - | yes |
 | ec2_scale_down_adjustment | Number of EC2 instances to scale down by at a time. Positive numbers will be converted to negative. | string | `-1` | no |
 | ec2_scale_down_cool_down | Time in seconds before any further trigger-related scaling can occur. | string | `60` | no |
 | ec2_scale_up_adjustment | Number of EC2 instances to scale up by at a time. | string | `1` | no |
@@ -55,7 +56,7 @@ Full working references are available at [examples](examples)
 | final_userdata_commands | Commands to be given at the end of userdata for an instance. This should generally not include bootstrapping or ssm install. | string | `` | no |
 | health_check_grace_period | Number of seconds grace during which no autoscaling actions will be taken. | string | `300` | no |
 | health_check_type | Define the type of healthcheck for the AutoScaling group. | string | `EC2` | no |
-| image_id | The AMI ID to be used to build the EC2 Instance. | string | - | yes |
+| image_id | The AMI ID to be used to build the EC2 Instance. If not provided, an AMI ID will be queried with an OS specified in variable ec2_os. | string | `` | no |
 | initial_userdata_commands | Commands to be given at the start of userdata for an instance. This should generally not include bootstrapping or ssm install. | string | `` | no |
 | install_codedeploy_agent | Install codedeploy agent on instance(s)? true or false | string | `false` | no |
 | instance_role_managed_policy_arn_count | The number of policy ARNs provided/set in variable 'instance_role_managed_policy_arns' | string | `0` | no |
@@ -87,5 +88,7 @@ Full working references are available at [examples](examples)
 
 | Name | Description |
 |------|-------------|
+| asg_image_id | Image ID used for EC2 provisioning |
 | asg_name_list | List of ASG names |
 | iam_role | Name of the created IAM Instance role. |
+

--- a/main.tf
+++ b/main.tf
@@ -150,17 +150,20 @@ EOF
   ssm_command_count = 6
 
   ebs_device_map = {
-    rhel6     = "/dev/sdf"
-    rhel7     = "/dev/sdf"
-    centos6   = "/dev/sdf"
-    centos7   = "/dev/sdf"
-    windows   = "xvdf"
-    ubuntu14  = "/dev/sdf"
-    ubuntu16  = "/dev/sdf"
-    ubuntu18  = "/dev/sdf"
-    amazon    = "/dev/sdf"
-    amazoneks = "/dev/sdf"
-    amazonecs = "/dev/xvdcz"
+    rhel6         = "/dev/sdf"
+    rhel7         = "/dev/sdf"
+    centos6       = "/dev/sdf"
+    centos7       = "/dev/sdf"
+    windows2008   = "xvdf"
+    windows2012R2 = "xvdf"
+    windows2016   = "xvdf"
+    ubuntu14      = "/dev/sdf"
+    ubuntu16      = "/dev/sdf"
+    ubuntu18      = "/dev/sdf"
+    amazon        = "/dev/sdf"
+    amazon2       = "/dev/sdf"
+    amazoneks     = "/dev/sdf"
+    amazonecs     = "/dev/xvdcz"
   }
 
   cwagent_config = "${var.ec2_os != "windows" ? "linux_cw_agent_param.txt" : "windows_cw_agent_param.txt"}"
@@ -209,18 +212,20 @@ EOF
   ]
 
   user_data_map = {
-    amazon    = "amazon_linux_userdata.sh"
-    amazon2   = "amazon_linux_userdata.sh"
-    amazoneks = "amazon_linux_userdata.sh"
-    amazonecs = "amazon_linux_userdata.sh"
-    rhel6     = "rhel_centos_6_userdata.sh"
-    rhel7     = "rhel_centos_7_userdata.sh"
-    centos6   = "rhel_centos_6_userdata.sh"
-    centos7   = "rhel_centos_7_userdata.sh"
-    ubuntu14  = "ubuntu_userdata.sh"
-    ubuntu16  = "ubuntu_userdata.sh"
-    ubuntu18  = "ubuntu_userdata.sh"
-    windows   = "windows_userdata.ps1"
+    amazon        = "amazon_linux_userdata.sh"
+    amazon2       = "amazon_linux_userdata.sh"
+    amazoneks     = "amazon_linux_userdata.sh"
+    amazonecs     = "amazon_linux_userdata.sh"
+    rhel6         = "rhel_centos_6_userdata.sh"
+    rhel7         = "rhel_centos_7_userdata.sh"
+    centos6       = "rhel_centos_6_userdata.sh"
+    centos7       = "rhel_centos_7_userdata.sh"
+    ubuntu14      = "ubuntu_userdata.sh"
+    ubuntu16      = "ubuntu_userdata.sh"
+    ubuntu18      = "ubuntu_userdata.sh"
+    windows2008   = "windows_userdata.ps1"
+    windows2012R2 = "windows_userdata.ps1"
+    windows2016   = "windows_userdata.ps1"
   }
 
   sns_topic = "arn:aws:sns:${data.aws_region.current_region.name}:${data.aws_caller_identity.current_account.account_id}:rackspace-support-emergency"
@@ -243,6 +248,210 @@ EOF
 
   alarm_setting = "${local.alarm_actions[local.alarm_action_config]}"
   ok_setting    = "${local.ok_actions[local.ok_action_config]}"
+
+  ami_owner_mapping = {
+    amazon        = "137112412989"
+    amazon2       = "137112412989"
+    centos6       = "679593333241"
+    centos7       = "679593333241"
+    rhel6         = "309956199498"
+    rhel7         = "309956199498"
+    ubuntu14      = "099720109477"
+    ubuntu16      = "099720109477"
+    ubuntu18      = "099720109477"
+    windows2008   = "801119661308"
+    windows2012R2 = "801119661308"
+    windows2016   = "801119661308"
+  }
+
+  ami_filter_mapping = {
+    amazon = [
+      {
+        name   = "name"
+        values = ["amzn-ami-hvm-2018.03.0.*gp2"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    amazon2 = [
+      {
+        name   = "name"
+        values = ["amzn2-ami-hvm-2.0.*-ebs"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    centos6 = [
+      {
+        name   = "name"
+        values = ["CentOS Linux 6 x86_64 HVM EBS*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    centos7 = [
+      {
+        name   = "name"
+        values = ["CentOS Linux 7 x86_64 HVM EBS*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    rhel6 = [
+      {
+        name   = "name"
+        values = ["RHEL-6.*_HVM_GA-*x86_64*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    rhel7 = [
+      {
+        name   = "name"
+        values = ["RHEL-7.*_HVM_GA-*x86_64*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    ubuntu14 = [
+      {
+        name   = "name"
+        values = ["*ubuntu-trusty-14.04-amd64-server*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    ubuntu16 = [
+      {
+        name   = "name"
+        values = ["*ubuntu-xenial-16.04-amd64-server*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    ubuntu18 = [
+      {
+        name   = "name"
+        values = ["*ubuntu-bionic-18.04-amd64-server*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    windows2008 = [
+      {
+        name   = "name"
+        values = ["Windows_Server-2008-R2_SP1-English-64Bit-Base*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    windows2012R2 = [
+      {
+        name   = "name"
+        values = ["Windows_Server-2012-R2_RTM-English-64Bit-Base*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    windows2016 = [
+      {
+        name   = "name"
+        values = ["Windows_Server-2016-English-Full-Base*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+  }
+}
+
+# Lookup the correct AMI based on the region specified
+data "aws_ami" "asg_ami" {
+  most_recent = true
+  owners      = ["${local.ami_owner_mapping[var.ec2_os]}"]
+  filter      = ["${local.ami_filter_mapping[var.ec2_os]}"]
 }
 
 data "template_file" "user_data" {
@@ -365,7 +574,7 @@ resource "aws_launch_configuration" "launch_config_with_secondary_ebs" {
   count                = "${var.secondary_ebs_volume_size != "" ? 1 : 0}"
   user_data_base64     = "${base64encode(data.template_file.user_data.rendered)}"
   enable_monitoring    = "${var.detailed_monitoring}"
-  image_id             = "${var.image_id}"
+  image_id             = "${var.image_id != "" ? var.image_id : data.aws_ami.asg_ami.image_id}"
   key_name             = "${var.key_pair}"
   security_groups      = ["${var.security_group_list}"]
   placement_tenancy    = "${var.tenancy}"
@@ -397,7 +606,7 @@ resource "aws_launch_configuration" "launch_config_no_secondary_ebs" {
   count                = "${var.secondary_ebs_volume_size != "" ? 0 : 1}"
   user_data_base64     = "${base64encode(data.template_file.user_data.rendered)}"
   enable_monitoring    = "${var.detailed_monitoring}"
-  image_id             = "${var.image_id}"
+  image_id             = "${var.image_id != "" ? var.image_id : data.aws_ami.asg_ami.image_id}"
   key_name             = "${var.key_pair}"
   security_groups      = ["${var.security_group_list}"]
   placement_tenancy    = "${var.tenancy}"

--- a/main.tf
+++ b/main.tf
@@ -264,186 +264,19 @@ EOF
     windows2016   = "801119661308"
   }
 
-  ami_filter_mapping = {
-    amazon = [
-      {
-        name   = "name"
-        values = ["amzn-ami-hvm-2018.03.0.*gp2"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    amazon2 = [
-      {
-        name   = "name"
-        values = ["amzn2-ami-hvm-2.0.*-ebs"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    centos6 = [
-      {
-        name   = "name"
-        values = ["CentOS Linux 6 x86_64 HVM EBS*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    centos7 = [
-      {
-        name   = "name"
-        values = ["CentOS Linux 7 x86_64 HVM EBS*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    rhel6 = [
-      {
-        name   = "name"
-        values = ["RHEL-6.*_HVM_GA-*x86_64*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    rhel7 = [
-      {
-        name   = "name"
-        values = ["RHEL-7.*_HVM_GA-*x86_64*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    ubuntu14 = [
-      {
-        name   = "name"
-        values = ["*ubuntu-trusty-14.04-amd64-server*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    ubuntu16 = [
-      {
-        name   = "name"
-        values = ["*ubuntu-xenial-16.04-amd64-server*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    ubuntu18 = [
-      {
-        name   = "name"
-        values = ["*ubuntu-bionic-18.04-amd64-server*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    windows2008 = [
-      {
-        name   = "name"
-        values = ["Windows_Server-2008-R2_SP1-English-64Bit-Base*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    windows2012R2 = [
-      {
-        name   = "name"
-        values = ["Windows_Server-2012-R2_RTM-English-64Bit-Base*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    windows2016 = [
-      {
-        name   = "name"
-        values = ["Windows_Server-2016-English-Full-Base*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
+  ami_name_mapping = {
+    amazon        = "amzn-ami-hvm-2018.03.0.*gp2"
+    amazon2       = "amzn2-ami-hvm-2.0.*-ebs"
+    centos6       = "CentOS Linux 6 x86_64 HVM EBS*"
+    centos7       = "CentOS Linux 7 x86_64 HVM EBS*"
+    rhel6         = "RHEL-6.*_HVM_GA-*x86_64*"
+    rhel7         = "RHEL-7.*_HVM_GA-*x86_64*"
+    ubuntu14      = "*ubuntu-trusty-14.04-amd64-server*"
+    ubuntu16      = "*ubuntu-xenial-16.04-amd64-server*"
+    ubuntu18      = "*ubuntu-bionic-18.04-amd64-server*"
+    windows2008   = "Windows_Server-2008-R2_SP1-English-64Bit-Base*"
+    windows2012R2 = "Windows_Server-2012-R2_RTM-English-64Bit-Base*"
+    windows2016   = "Windows_Server-2016-English-Full-Base*"
   }
 }
 
@@ -451,7 +284,21 @@ EOF
 data "aws_ami" "asg_ami" {
   most_recent = true
   owners      = ["${local.ami_owner_mapping[var.ec2_os]}"]
-  filter      = ["${local.ami_filter_mapping[var.ec2_os]}"]
+
+  filter {
+    name   = "name"
+    values = ["${local.ami_name_mapping[var.ec2_os]}"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 }
 
 data "template_file" "user_data" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "iam_role" {
   description = "Name of the created IAM Instance role."
   value       = "${aws_iam_role.mod_ec2_instance_role.id}"
 }
+
+output "asg_image_id" {
+  description = "Image ID used for EC2 provisioning"
+  value       = "${var.image_id != "" ? var.image_id : data.aws_ami.asg_ami.image_id}"
+}

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -89,7 +89,6 @@ module "ec2_asg_centos7_with_codedeploy" {
   subnets                                = ["${element(module.vpc.public_subnets, 0)}", "${element(module.vpc.public_subnets, 1)}"]
   secondary_ebs_volume_iops              = "0"
   ec2_scale_down_adjustment              = "1"
-  image_id                               = "${data.aws_ami.amazon_centos_7.image_id}"
   cw_low_period                          = "300"
   key_pair                               = "CircleCI"
   tenancy                                = "default"
@@ -305,7 +304,7 @@ EOF
 
 module "ec2_asg_windows_with_codedeploy" {
   source    = "../../module"
-  ec2_os    = "windows"
+  ec2_os    = "windows2016"
   asg_count = "2"
 
   #  load_balancer_names                    = ["${aws_elb.my_elb.name}"]
@@ -423,7 +422,7 @@ EOF
 
 module "ec2_asg_windows_no_codedeploy" {
   source    = "../../module"
-  ec2_os    = "windows"
+  ec2_os    = "windows2016"
   asg_count = "2"
 
   #  load_balancer_names                    = ["${aws_elb.my_elb.name}"]

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,7 @@ variable "detailed_monitoring" {
 }
 
 variable "ec2_os" {
-  description = "Intended Operating System/Distribution of Instance. Valid inputs are ('amazon', 'rhel6', 'rhel7', 'centos6', 'centos7', 'ubuntu14', 'ubuntu16', 'windows')"
+  description = "Intended Operating System/Distribution of Instance. Valid inputs are ('amazon', 'rhel6', 'rhel7', 'centos6', 'centos7', 'ubuntu14', 'ubuntu16', 'windows2008', 'windows2012R2', 'windows2016')"
   type        = "string"
 }
 
@@ -50,8 +50,9 @@ variable "health_check_type" {
 }
 
 variable "image_id" {
-  description = "The AMI ID to be used to build the EC2 Instance."
+  description = "The AMI ID to be used to build the EC2 Instance. If not provided, an AMI ID will be queried with an OS specified in variable ec2_os."
   type        = "string"
+  default     = ""
 }
 
 variable "install_codedeploy_agent" {


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/122
##### Summary of change(s):
- Make `image_id` an optional variable
- If `image_id` is not provided, a suitable AMI will be queried using a data resource based on input provided in variable `ec2_os`
- Update README
- Add output for Image ID

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
- Yes, if Image ID is not manually provided to the module.
- Will cause destruction in tests due to change in tests.
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
N/A

##### If input variables or output variables have changed or has been added, have you updated the README?
YES
##### Do examples need to be updated based on changes?

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.