### PR TITLE
adding an option to encrypt the primary ebs volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Full working references are available at [examples](examples)
 | enable\_ebs\_optimization | Use EBS Optimized? true or false | string | `"false"` | no |
 | enable\_rolling\_updates | Should this autoscaling group be targeted by the ASG Instance Replacement tool to ensure all instances are using thelatest launch configuration. | string | `"true"` | no |
 | enable\_scaling\_notification | true or false. If 'scaling_notification_topic' is set to a non-empty string, this must be set to true. Otherwise, set to false. This variable exists due to a terraform limitation with using count and computed values as conditionals | string | `"false"` | no |
+| encrypt\_primary\_ebs\_volume | Encrypt primary EBS Volume? true or false | string | `"false"` | no |
 | encrypt\_secondary\_ebs\_volume | Encrypt secondary EBS Volume? true or false | string | `"false"` | no |
 | environment | Application environment for which this network is being created. Preferred value are Development, Integration, PreProduction, Production, QA, Staging, or Test | string | `"Development"` | no |
 | final\_userdata\_commands | Commands to be given at the end of userdata for an instance. This should generally not include bootstrapping or ssm install. | string | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -423,6 +423,7 @@ resource "aws_launch_configuration" "launch_config_with_secondary_ebs" {
     volume_type = "${var.primary_ebs_volume_type}"
     volume_size = "${var.primary_ebs_volume_size}"
     iops        = "${var.primary_ebs_volume_type == "io1" ? var.primary_ebs_volume_size : 0}"
+    encrypted   = "${var.encrypt_primary_ebs_volume}"
   }
 
   ebs_block_device {

--- a/variables.tf
+++ b/variables.tf
@@ -171,6 +171,12 @@ variable "enable_ebs_optimization" {
   default     = false
 }
 
+variable "encrypt_primary_ebs_volume" {
+  description = "Encrypt primary EBS Volume? true or false"
+  type        = "string"
+  default     = false
+}
+
 variable "encrypt_secondary_ebs_volume" {
   description = "Encrypt secondary EBS Volume? true or false"
   type        = "string"


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):

No recorded issue, just have the need.

##### Summary of change(s):

Added an option to set the primary EBS volume's encryption.  Just like the secondary option. Default to false

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

Should not, as there is a default.

##### If input variables or output variables have changed or has been added, have you updated the README?

yes

##### Do examples need to be updated based on changes?

I don't think so...

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.