### PR TITLE
Update default AMI filter to allow custom filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module creates one or more autoscaling groups.
 
 ```
 module "asg" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.0.11"
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.0.15"
 
  ec2_os              = "amazon"
  subnets             = ["${module.vpc.private_subnets}"]

--- a/examples/basic_usage.tf
+++ b/examples/basic_usage.tf
@@ -49,7 +49,7 @@ module "sns_sqs" {
 }
 
 module "ec2_asg" {
-  source    = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.0.11"
+  source    = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.0.15"
   ec2_os    = "centos7"
   asg_count = "2"
 

--- a/examples/custom_cw_config.tf
+++ b/examples/custom_cw_config.tf
@@ -49,7 +49,7 @@ module "sns_sqs" {
 }
 
 module "ec2_asg" {
-  source    = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.0.9"
+  source    = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.0.15"
   ec2_os    = "centos7"
   asg_count = "2"
 

--- a/main.tf
+++ b/main.tf
@@ -277,6 +277,7 @@ EOF
     windows2016   = "Windows_Server-2016-English-Full-Base*"
   }
 
+  # Any custom AMI filters for a given OS can be added in this mapping
   image_filter = {
     amazon        = []
     amazon2       = []
@@ -291,6 +292,7 @@ EOF
     windows2012R2 = []
     windows2016   = []
 
+    # Added to ensure only AMIS under the official CentOS 6 product code are retrieved
     centos6 = [
       {
         name   = "product-code"
@@ -298,6 +300,7 @@ EOF
       },
     ]
 
+    # Added to ensure only AMIS under the official CentOS 7 product code are retrieved
     centos7 = [
       {
         name   = "product-code"

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@
  *
  *```
  *module "asg" {
- *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.0.11"
+ *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.0.15"
  *
  *  ec2_os              = "amazon"
  *  subnets             = ["${module.vpc.private_subnets}"]
@@ -276,27 +276,57 @@ EOF
     windows2012R2 = "Windows_Server-2012-R2_RTM-English-64Bit-Base*"
     windows2016   = "Windows_Server-2016-English-Full-Base*"
   }
+
+  image_filter = {
+    amazon        = []
+    amazon2       = []
+    amazonecs     = []
+    amazoneks     = []
+    rhel6         = []
+    rhel7         = []
+    ubuntu14      = []
+    ubuntu16      = []
+    ubuntu18      = []
+    windows2008   = []
+    windows2012R2 = []
+    windows2016   = []
+
+    centos6 = [
+      {
+        name   = "product-code"
+        values = ["6x5jmcajty9edm3f211pqjfn2"]
+      },
+    ]
+
+    centos7 = [
+      {
+        name   = "product-code"
+        values = ["aw0evgkw8e5c1q413zgy5pjce"]
+      },
+    ]
+  }
+
+  standard_filters = [
+    {
+      name   = "virtualization-type"
+      values = ["hvm"]
+    },
+    {
+      name   = "root-device-type"
+      values = ["ebs"]
+    },
+    {
+      name   = "name"
+      values = ["${local.ami_name_mapping[var.ec2_os]}"]
+    },
+  ]
 }
 
 # Lookup the correct AMI based on the region specified
 data "aws_ami" "asg_ami" {
   most_recent = true
   owners      = ["${local.ami_owner_mapping[var.ec2_os]}"]
-
-  filter {
-    name   = "name"
-    values = ["${local.ami_name_mapping[var.ec2_os]}"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
+  filter      = "${concat(local.standard_filters, local.image_filter[var.ec2_os])}"
 }
 
 data "template_file" "user_data" {

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -9,25 +9,6 @@ provider "random" {
 
 data "aws_region" "current_region" {}
 
-data "aws_ami" "amazon_centos_7" {
-  most_recent = true
-  owners      = ["679593333241"]
-
-  filter {
-    name   = "name"
-    values = ["CentOS Linux 7 x86_64 HVM EBS*"]
-  }
-}
-
-data "aws_ami" "amazon_windows_2016" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["Windows_Server-2016-English-Full-Base-*"]
-  }
-}
-
 resource "random_string" "password" {
   length      = 16
   special     = false
@@ -214,7 +195,6 @@ module "ec2_asg_centos7_no_codedeploy_test" {
   subnets                                = ["${element(module.vpc.public_subnets, 0)}", "${element(module.vpc.public_subnets, 1)}"]
   secondary_ebs_volume_iops              = "0"
   ec2_scale_down_adjustment              = "1"
-  image_id                               = "${data.aws_ami.amazon_centos_7.image_id}"
   cw_low_period                          = "300"
   key_pair                               = "CircleCI"
   tenancy                                = "default"
@@ -335,7 +315,6 @@ module "ec2_asg_windows_with_codedeploy_test" {
   subnets                                = ["${element(module.vpc.public_subnets, 0)}", "${element(module.vpc.public_subnets, 1)}"]
   secondary_ebs_volume_iops              = "0"
   ec2_scale_down_adjustment              = "1"
-  image_id                               = "${data.aws_ami.amazon_windows_2016.image_id}"
   cw_low_period                          = "300"
   key_pair                               = "CircleCI"
   tenancy                                = "default"
@@ -453,7 +432,6 @@ module "ec2_asg_windows_no_codedeploy_test" {
   subnets                                = ["${element(module.vpc.public_subnets, 0)}", "${element(module.vpc.public_subnets, 1)}"]
   secondary_ebs_volume_iops              = "0"
   ec2_scale_down_adjustment              = "1"
-  image_id                               = "${data.aws_ami.amazon_windows_2016.image_id}"
   cw_low_period                          = "300"
   key_pair                               = "CircleCI"
   tenancy                                = "default"


### PR DESCRIPTION
##### Corresponding Issue(s):
 - PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section
[MPCSUPENG-297](https://jira.rax.io/browse/MPCSUPENG-297)
##### Summary of change(s):
Updates AMI Filters to allow setting additional custom filters per OS.  Adds initial filters to limit CentOS AMIs to expected product codes.

##### Reason for Change(s):

- Build errors for CentOS 7 due to AMI with expected name but unexpected product code.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
Not in production deployments.
As default AMI has changed, launch configuration replacement will occur in testing, flagging the destructive check.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No

##### If input variables or output variables have changed or has been added, have you updated the README?
Yes, Readme updated

##### Do examples need to be updated based on changes?
Yes examples updated

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
