### PR TITLE
Remove userdata exit 0's when SSM is found because it blocks final cmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Full working references are available at [examples](examples)
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| additional\_ssm\_bootstrap\_list | A list of maps consisting of main step actions, to be appended to SSM associations. Please see usage.tf.example in this repo for examples. | list | `<list>` | no |
+| additional\_ssm\_bootstrap\_step\_count | Count of steps added for input 'additional_ssm_bootstrap_list'. This is required since 'additional_ssm_bootstrap_list' is a list of maps | string | `"0"` | no |
 | additional\_tags | Additional tags to be added to the ASG instance(s). Format: list of maps. Please see usage.tf.example in this repo for examples. | list | `<list>` | no |
-| addtional\_ssm\_bootstrap\_list | A list of maps consisting of main step actions, to be appended to SSM associations. Please see usage.tf.example in this repo for examples. | list | `<list>` | no |
-| addtional\_ssm\_bootstrap\_step\_count | Count of steps added for input 'addtional_ssm_bootstrap_list'. This is required since 'addtional_ssm_bootstrap_list' is a list of maps | string | `"0"` | no |
 | asg\_count | Number of identical ASG's to deploy | string | `"1"` | no |
 | asg\_wait\_for\_capacity\_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. | string | `"10m"` | no |
 | backup\_tag\_value | Value of the 'Backup' tag, used to assign te EBSSnapper configuration | string | `"False"` | no |

--- a/examples/basic_usage.tf
+++ b/examples/basic_usage.tf
@@ -104,7 +104,7 @@ module "ec2_asg" {
   cw_high_operator           = "GreaterThanThreshold"
   install_codedeploy_agent   = "False"
 
-  addtional_ssm_bootstrap_list = [
+  additional_ssm_bootstrap_list = [
     {
       ssm_add_step = <<EOF
       {
@@ -139,7 +139,7 @@ EOF
     },
   ]
 
-  addtional_ssm_bootstrap_step_count = "2"
+  additional_ssm_bootstrap_step_count = "2"
 
   additional_tags = [
     {

--- a/examples/custom_cw_config.tf
+++ b/examples/custom_cw_config.tf
@@ -104,7 +104,7 @@ module "ec2_asg" {
   cw_high_operator           = "GreaterThanThreshold"
   install_codedeploy_agent   = "False"
 
-  addtional_ssm_bootstrap_list = [
+  additional_ssm_bootstrap_list = [
     {
       ssm_add_step = <<EOF
       {
@@ -139,7 +139,7 @@ EOF
     },
   ]
 
-  addtional_ssm_bootstrap_step_count = "2"
+  additional_ssm_bootstrap_step_count = "2"
 
   additional_tags = [
     {

--- a/main.tf
+++ b/main.tf
@@ -679,11 +679,11 @@ data "template_file" "ssm_command_docs" {
 }
 
 data "template_file" "additional_ssm_docs" {
-  template = "$${addtional_ssm_cmd_json}"
-  count    = "${var.addtional_ssm_bootstrap_step_count}"
+  template = "$${additional_ssm_cmd_json}"
+  count    = "${var.additional_ssm_bootstrap_step_count}"
 
   vars {
-    addtional_ssm_cmd_json = "${lookup(var.addtional_ssm_bootstrap_list[count.index], "ssm_add_step")}"
+    additional_ssm_cmd_json = "${lookup(var.additional_ssm_bootstrap_list[count.index], "ssm_add_step")}"
   }
 }
 

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -108,7 +108,7 @@ module "ec2_asg_centos7_with_codedeploy_test" {
   cw_high_operator           = "GreaterThanThreshold"
   install_codedeploy_agent   = "False"
 
-  addtional_ssm_bootstrap_list = [
+  additional_ssm_bootstrap_list = [
     {
       ssm_add_step = <<EOF
       {
@@ -143,7 +143,7 @@ EOF
     },
   ]
 
-  addtional_ssm_bootstrap_step_count = "2"
+  additional_ssm_bootstrap_step_count = "2"
 
   additional_tags = [
     {
@@ -228,7 +228,7 @@ module "ec2_asg_centos7_no_codedeploy_test" {
   cw_high_operator           = "GreaterThanThreshold"
   install_codedeploy_agent   = "False"
 
-  addtional_ssm_bootstrap_list = [
+  additional_ssm_bootstrap_list = [
     {
       ssm_add_step = <<EOF
       {
@@ -263,7 +263,7 @@ EOF
     },
   ]
 
-  addtional_ssm_bootstrap_step_count = "2"
+  additional_ssm_bootstrap_step_count = "2"
 
   additional_tags = [
     {
@@ -348,7 +348,7 @@ module "ec2_asg_windows_with_codedeploy_test" {
   cw_high_operator           = "GreaterThanThreshold"
   install_codedeploy_agent   = "False"
 
-  addtional_ssm_bootstrap_list = [
+  additional_ssm_bootstrap_list = [
     {
       ssm_add_step = <<EOF
       {
@@ -380,7 +380,7 @@ EOF
     },
   ]
 
-  addtional_ssm_bootstrap_step_count = "2"
+  additional_ssm_bootstrap_step_count = "2"
 
   additional_tags = [
     {
@@ -465,7 +465,7 @@ module "ec2_asg_windows_no_codedeploy_test" {
   cw_high_operator           = "GreaterThanThreshold"
   install_codedeploy_agent   = "False"
 
-  addtional_ssm_bootstrap_list = [
+  additional_ssm_bootstrap_list = [
     {
       ssm_add_step = <<EOF
       {
@@ -497,7 +497,7 @@ EOF
     },
   ]
 
-  addtional_ssm_bootstrap_step_count = "2"
+  additional_ssm_bootstrap_step_count = "2"
 
   additional_tags = [
     {

--- a/text/rhel_centos_6_userdata.sh
+++ b/text/rhel_centos_6_userdata.sh
@@ -13,7 +13,6 @@ pip install --upgrade awscli pystache argparse
 ssm_running=$( ps -ef | grep [a]mazon-ssm-agent | wc -l )
 if [[ $ssm_running != "0" ]]; then
     echo -e "amazon-ssm-agent already running"
-    exit 0
 else
     if [[ -r "/tmp/ssm_agent_install" ]]; then : ;
     else mkdir -p /tmp/ssm_agent_install; fi

--- a/text/rhel_centos_7_userdata.sh
+++ b/text/rhel_centos_7_userdata.sh
@@ -13,7 +13,6 @@ pip install --upgrade awscli pystache argparse
 ssm_running=$( ps -ef | grep [a]mazon-ssm-agent | wc -l )
 if [[ $ssm_running != "0" ]]; then
     echo -e "amazon-ssm-agent already running"
-    exit 0
 else
     if [[ -r "/tmp/ssm_agent_install" ]]; then : ;
     else mkdir -p /tmp/ssm_agent_install; fi

--- a/text/ubuntu_userdata.sh
+++ b/text/ubuntu_userdata.sh
@@ -12,7 +12,6 @@ pip install awscli --upgrade
 ssm_running=$( ps -ef | grep [a]mazon-ssm-agent | wc -l )
 if [[ $ssm_running != "0" ]]; then
     echo -e "amazon-ssm-agent already running"
-    exit 0
 else
     if [[ -r "/tmp/ssm_agent_install" ]]; then : ;
     else mkdir -p /tmp/ssm_agent_install; fi

--- a/variables.tf
+++ b/variables.tf
@@ -261,14 +261,14 @@ variable "instance_role_managed_policy_arn_count" {
 # SSM and Associations
 #
 
-variable "addtional_ssm_bootstrap_list" {
+variable "additional_ssm_bootstrap_list" {
   description = "A list of maps consisting of main step actions, to be appended to SSM associations. Please see usage.tf.example in this repo for examples."
   type        = "list"
   default     = []
 }
 
-variable "addtional_ssm_bootstrap_step_count" {
-  description = "Count of steps added for input 'addtional_ssm_bootstrap_list'. This is required since 'addtional_ssm_bootstrap_list' is a list of maps"
+variable "additional_ssm_bootstrap_step_count" {
+  description = "Count of steps added for input 'additional_ssm_bootstrap_list'. This is required since 'additional_ssm_bootstrap_list' is a list of maps"
   type        = "string"
   default     = "0"
 }


### PR DESCRIPTION
##### Corresponding Issue(s):
 <!--- PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section --->

None

##### Summary of change(s):

- Remove `exit 0` when SSM is found in CentOS, RHEL7 and Ubuntu userdata text files
- Fix incorrect `addtional` by replacing with `additional`

##### Reason for Change(s):

The exit stops the final userdata commands running if SSM happens to be found

Spelling

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No, but moving to the new tag would require changing input variables if using the additional SSM arguments

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

No

##### If input variables or output variables have changed or has been added, have you updated the README?

Yes, done

##### Do examples need to be updated based on changes?

Yes, done

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
