### PR TITLE
Fix logic for testing if var.ec2_os is windows*

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,24 @@ This module creates one or more autoscaling groups.
 
 ## Basic Usage
 
-```
+```HCL
 module "asg" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.0.18"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.0.21"
 
- ec2_os              = "amazon"
- subnets             = ["${module.vpc.private_subnets}"]
- image_id            = "${var.image_id}"
- resource_name       = "my_asg"
- security_group_list = ["${module.sg.private_web_security_group_id}"]
+  ec2_os              = "amazon"
+  subnets             = ["${module.vpc.private_subnets}"]
+  image_id            = "${var.image_id}"
+  resource_name       = "my_asg"
+  security_group_list = ["${module.sg.private_web_security_group_id}"]
 }
 ```
 
 Full working references are available at [examples](examples)
- ## Other TF Modules Used
+
+## Other TF Modules Used
+
 Using [aws-terraform-cloudwatch_alarm](https://github.com/rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm) to create the following CloudWatch Alarms:
-	- group_terminating_instances
-	- scale_alarm_high
-	- scale_alarm_low
+- group_terminating_instances
 
 ## Inputs
 
@@ -45,7 +45,7 @@ Using [aws-terraform-cloudwatch_alarm](https://github.com/rackspace-infrastructu
 | cw\_low\_threshold | The value against which the specified statistic is compared. | string | `"30"` | no |
 | cw\_scaling\_metric | The metric to be used for scaling. | string | `"CPUUtilization"` | no |
 | detailed\_monitoring | Enable Detailed Monitoring? true or false | string | `"true"` | no |
-| ec2\_os | Intended Operating System/Distribution of Instance. Valid inputs are ('amazon', 'rhel6', 'rhel7', 'centos6', 'centos7', 'ubuntu14', 'ubuntu16', 'windows2008', 'windows2012R2', 'windows2016') | string | n/a | yes |
+| ec2\_os | Intended Operating System/Distribution of Instance. Valid inputs are: `amazon`, `amazon2`, `amazoneks`, `amazonecs`, `rhel6`, `rhel7`, `centos6`, `centos7`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `windows2008`, `windows2012r2`, `windows2016`, `windows2019` | string | n/a | yes |
 | ec2\_scale\_down\_adjustment | Number of EC2 instances to scale down by at a time. Positive numbers will be converted to negative. | string | `"-1"` | no |
 | ec2\_scale\_down\_cool\_down | Time in seconds before any further trigger-related scaling can occur. | string | `"60"` | no |
 | ec2\_scale\_up\_adjustment | Number of EC2 instances to scale up by at a time. | string | `"1"` | no |

--- a/examples/basic_usage.tf
+++ b/examples/basic_usage.tf
@@ -40,7 +40,8 @@ resource "aws_sqs_queue" "ec2-asg-test_sqs" {
 }
 
 module "sns_sqs" {
-  source     = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns?ref=v0.0.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns?ref=v0.0.2"
+
   topic_name = "${random_string.sqs_rstring.result}-ec2-asg-test-topic"
 
   create_subscription_1 = true
@@ -49,7 +50,8 @@ module "sns_sqs" {
 }
 
 module "ec2_asg" {
-  source    = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.0.20"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.0.21"
+
   ec2_os    = "centos7"
   asg_count = "2"
 

--- a/examples/custom_cw_config.tf
+++ b/examples/custom_cw_config.tf
@@ -40,7 +40,8 @@ resource "aws_sqs_queue" "ec2-asg-test_sqs" {
 }
 
 module "sns_sqs" {
-  source     = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns?ref=v0.0.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns?ref=v0.0.2"
+
   topic_name = "${random_string.sqs_rstring.result}-ec2-asg-test-topic"
 
   create_subscription_1 = true
@@ -49,7 +50,8 @@ module "sns_sqs" {
 }
 
 module "ec2_asg" {
-  source    = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.0.20"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.0.21"
+
   ec2_os    = "centos7"
   asg_count = "2"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "asg_image_id" {
+  description = "Image ID used for EC2 provisioning"
+  value       = "${var.image_id != "" ? var.image_id : data.aws_ami.asg_ami.image_id}"
+}
+
 output "asg_name_list" {
   description = "List of ASG names"
   value       = ["${aws_autoscaling_group.autoscalegrp.*.name}"]
@@ -6,9 +11,4 @@ output "asg_name_list" {
 output "iam_role" {
   description = "Name of the created IAM Instance role."
   value       = "${element(coalescelist(aws_iam_role.mod_ec2_instance_role.*.id, list("none")), 0)}"
-}
-
-output "asg_image_id" {
-  description = "Image ID used for EC2 provisioning"
-  value       = "${var.image_id != "" ? var.image_id : data.aws_ami.asg_ami.image_id}"
 }

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -39,16 +39,17 @@ resource "aws_sqs_queue" "ec2-asg-test_sqs" {
 }
 
 module "sns_sqs" {
-  source     = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns?ref=master"
-  topic_name = "${random_string.sqs_rstring.result}-ec2-asg-test-topic"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns?ref=master"
 
   create_subscription_1 = true
-  protocol_1            = "sqs"
   endpoint_1            = "${aws_sqs_queue.ec2-asg-test_sqs.arn}"
+  protocol_1            = "sqs"
+  topic_name            = "${random_string.sqs_rstring.result}-ec2-asg-test-topic"
 }
 
 module "ec2_asg_centos7_with_codedeploy_test" {
-  source    = "../../module"
+  source = "../../module"
+
   ec2_os    = "centos7"
   asg_count = "2"
 
@@ -168,7 +169,8 @@ EOF
 }
 
 module "ec2_asg_centos7_no_codedeploy_test" {
-  source    = "../../module"
+  source = "../../module"
+
   ec2_os    = "centos7"
   asg_count = "2"
 
@@ -288,7 +290,8 @@ EOF
 }
 
 module "ec2_asg_windows_with_codedeploy_test" {
-  source    = "../../module"
+  source = "../../module"
+
   ec2_os    = "windows2016"
   asg_count = "2"
 
@@ -405,7 +408,8 @@ EOF
 }
 
 module "ec2_asg_windows_no_codedeploy_test" {
-  source    = "../../module"
+  source = "../../module"
+
   ec2_os    = "windows2016"
   asg_count = "2"
 

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,7 @@ variable "detailed_monitoring" {
 }
 
 variable "ec2_os" {
-  description = "Intended Operating System/Distribution of Instance. Valid inputs are ('amazon', 'rhel6', 'rhel7', 'centos6', 'centos7', 'ubuntu14', 'ubuntu16', 'windows2008', 'windows2012R2', 'windows2016')"
+  description = "Intended Operating System/Distribution of Instance. Valid inputs are: `amazon`, `amazon2`, `amazoneks`, `amazonecs`, `rhel6`, `rhel7`, `centos6`, `centos7`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `windows2008`, `windows2012r2`, `windows2016`, `windows2019`"
   type        = "string"
 }
 


### PR DESCRIPTION
##### Corresponding Issue(s):
<!--- PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section --->

N/A

##### Summary of change(s):

- general formatting to start aligning to standards
- old `windows` testing logic did not take into account changing to per Windows release years

##### Reason for Change(s):

<!--- If a bug, describe error scenario, including expected behavior and actual behavior. --->

<!--- If an enhancement, describe the use case and the perceived benefit(s). --->

Using a windows* flavour would not result in correct CW agent params.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

Should only update CW agent SSM parameter

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

No

##### If input variables or output variables have changed or has been added, have you updated the README?

Done

##### Do examples need to be updated based on changes?

Done

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
