### PR TITLE
Address Deprecated AWS Managed Policies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -417,6 +417,32 @@ data "aws_iam_policy_document" "mod_ec2_instance_role_policies" {
   }
 
   statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:GetEncryptionConfiguration",
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetBucketLocation",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
     effect    = "Allow"
     actions   = ["ec2:DescribeTags"]
     resources = ["*"]
@@ -439,11 +465,25 @@ resource "aws_iam_role" "mod_ec2_instance_role" {
   assume_role_policy = "${data.aws_iam_policy_document.mod_ec2_assume_role_policy_doc.json}"
 }
 
-resource "aws_iam_role_policy_attachment" "attach_ssm_policy" {
+resource "aws_iam_role_policy_attachment" "attach_core_ssm_policy" {
   count = "${var.instance_profile_override ? 0 : 1}"
 
   role       = "${aws_iam_role.mod_ec2_instance_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "attach_cw_ssm_policy" {
+  count = "${var.instance_profile_override ? 0 : 1}"
+
+  role       = "${aws_iam_role.mod_ec2_instance_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "attach_ad_ssm_policy" {
+  count = "${var.instance_profile_override ? 0 : 1}"
+
+  role       = "${aws_iam_role.mod_ec2_instance_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMDirectoryServiceAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "attach_codedeploy_policy" {

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -58,7 +58,7 @@ module "ec2_asg_centos7_with_codedeploy_test" {
 
   instance_role_managed_policy_arns = [
     "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
-    "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole",
+    "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole",
     "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access",
   ]
 
@@ -179,7 +179,7 @@ module "ec2_asg_centos7_no_codedeploy_test" {
 
   instance_role_managed_policy_arns = [
     "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
-    "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole",
+    "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole",
     "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access",
   ]
 
@@ -300,7 +300,7 @@ module "ec2_asg_windows_with_codedeploy_test" {
 
   instance_role_managed_policy_arns = [
     "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
-    "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole",
+    "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole",
     "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access",
   ]
 
@@ -418,7 +418,7 @@ module "ec2_asg_windows_no_codedeploy_test" {
 
   instance_role_managed_policy_arns = [
     "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
-    "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole",
+    "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole",
     "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access",
   ]
 


### PR DESCRIPTION
* The SSM Managed EC2 policy is now broken up into 4 individual policies. Being a generic module, this change makes the permissions the same as what they were with the previous managed policy.
* Also update the EC2 spot managed policy in both tests and the main terraform file.

### Testing

* This change was tested by manually running the tests file within the module repository
