### PR TITLE
Optional installation of ScaleFT agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Using [aws-terraform-cloudwatch_alarm](https://github.com/rackspace-infrastructu
 | image\_id | The AMI ID to be used to build the EC2 Instance. If not provided, an AMI ID will be queried with an OS specified in variable ec2_os. | string | `""` | no |
 | initial\_userdata\_commands | Commands to be given at the start of userdata for an instance. This should generally not include bootstrapping or ssm install. | string | `""` | no |
 | install\_codedeploy\_agent | Install codedeploy agent on instance(s)? true or false | string | `"false"` | no |
+| install\_scaleft\_agent | Install scaleft agent on instance(s)? true or false | string | `"true"` | no |
 | instance\_profile\_override | Optionally provide an instance profile. Any override profile should contain the permissions required for Rackspace support tooling to continue to function if required. | string | `"false"` | no |
 | instance\_profile\_override\_name | Provide an instance profile name. Any override profile should contain the permissions required for Rackspace support tooling to continue to function if required. To use this set `instance_profile_override` to `true`. | string | `""` | no |
 | instance\_role\_managed\_policy\_arn\_count | The number of policy ARNs provided/set in variable 'instance_role_managed_policy_arns' | string | `"0"` | no |

--- a/main.tf
+++ b/main.tf
@@ -103,19 +103,6 @@ EOF
       {
         "action": "aws:runDocument",
         "inputs": {
-          "documentPath": "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-Install_ScaleFT",
-          "documentType": "SSMDocument"
-        },
-        "name": "SetupPassport",
-        "timeoutSeconds": 300
-      }
-EOF
-    },
-    {
-      ssm_add_step = <<EOF
-      {
-        "action": "aws:runDocument",
-        "inputs": {
           "documentPath": "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-Install_Package",
           "documentParameters": {
             "Packages": "sysstat ltrace strace iptraf tcpdump"
@@ -170,7 +157,24 @@ EOF
     disabled = ""
   }
 
+  ssm_scaleft_include = {
+    enabled = <<EOF
+    {
+      "action": "aws:runDocument",
+      "inputs": {
+        "documentPath": "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-Install_ScaleFT",
+        "documentType": "SSMDocument"
+      },
+      "name": "SetupPassport",
+      "timeoutSeconds": 300
+    }
+EOF
+
+    disabled = ""
+  }
+
   codedeploy_install = "${var.install_codedeploy_agent ? "enabled" : "disabled"}"
+  scaleft_install    = "${var.install_scaleft_agent ? "enabled" : "disabled"}"
 
   ssm_command_count = 6
 
@@ -767,7 +771,7 @@ data "template_file" "ssm_bootstrap_template" {
   template = "${file("${path.module}/text/ssm_bootstrap_template.json")}"
 
   vars {
-    run_command_list = "${join(",",compact(concat(data.template_file.ssm_command_docs.*.rendered, list(local.ssm_codedeploy_include[local.codedeploy_install]), data.template_file.additional_ssm_docs.*.rendered)))}"
+    run_command_list = "${join(",",compact(concat(data.template_file.ssm_command_docs.*.rendered, list(local.ssm_codedeploy_include[local.codedeploy_install]), list(local.ssm_scaleft_include[local.scaleft_install]), data.template_file.additional_ssm_docs.*.rendered)))}"
   }
 }
 

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -289,6 +289,128 @@ EOF
   asg_wait_for_capacity_timeout = "10m"
 }
 
+module "ec2_asg_centos7_no_scaleft_test" {
+  source = "../../module"
+
+  ec2_os    = "centos7"
+  asg_count = "2"
+
+  #  load_balancer_names                    = ["${aws_elb.my_elb.name}"]
+  cw_low_operator = "LessThanThreshold"
+
+  instance_role_managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
+    "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole",
+    "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access",
+  ]
+
+  instance_role_managed_policy_arn_count = "2"
+  environment                            = "Development"
+  ssm_association_refresh_rate           = "rate(1 day)"
+  cw_scaling_metric                      = "CPUUtilization"
+  enable_ebs_optimization                = "False"
+  scaling_min                            = "1"
+  cloudwatch_log_retention               = "30"
+  secondary_ebs_volume_size              = "60"
+  rackspace_managed                      = true
+  cw_high_period                         = "60"
+  enable_scaling_notification            = true
+  subnets                                = ["${element(module.vpc.public_subnets, 0)}", "${element(module.vpc.public_subnets, 1)}"]
+  secondary_ebs_volume_iops              = "0"
+  ec2_scale_down_adjustment              = "1"
+  cw_low_period                          = "300"
+  key_pair                               = "CircleCI"
+  tenancy                                = "default"
+  backup_tag_value                       = "False"
+  ec2_scale_down_cool_down               = "60"
+  instance_type                          = "t2.micro"
+
+  # If ALB target groups are being used, one can specify ARNs like the commented line below.
+  #target_group_arns                      = ["${aws_lb_target_group.my_tg.arn}"]
+  secondary_ebs_volume_type = "gp2"
+
+  ec2_scale_up_adjustment    = "1"
+  cw_high_threshold          = "60"
+  scaling_notification_topic = "${module.sns_sqs.topic_arn}"
+  cw_low_threshold           = "30"
+  resource_name              = "${random_string.name_rstring.result}-ec2_asg_centos7_no_scaleft"
+  ec2_scale_up_cool_down     = "60"
+  ssm_patching_group         = "Group1Patching"
+  health_check_grace_period  = "300"
+  security_group_list        = ["${module.vpc.default_sg}"]
+  perform_ssm_inventory_tag  = "True"
+  terminated_instances       = "30"
+  health_check_type          = "EC2"
+  cw_low_evaluations         = "3"
+  cw_high_evaluations        = "3"
+  primary_ebs_volume_iops    = "0"
+  detailed_monitoring        = "True"
+  primary_ebs_volume_type    = "gp2"
+  primary_ebs_volume_size    = "60"
+  scaling_max                = "2"
+  cw_high_operator           = "GreaterThanThreshold"
+  install_codedeploy_agent   = "False"
+  install_scaleft_agent      = "False"
+
+  additional_ssm_bootstrap_list = [
+    {
+      ssm_add_step = <<EOF
+      {
+        "action": "aws:runDocument",
+        "inputs": {
+          "documentPath": "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-Install_Package",
+          "documentParameters": {
+            "Packages": "bind bindutils"
+          },
+          "documentType": "SSMDocument"
+        },
+        "name": "InstallBindAndTools",
+        "timeoutSeconds": 300
+      }
+EOF
+    },
+    {
+      ssm_add_step = <<EOF
+      {
+        "action": "aws:runDocument",
+        "inputs": {
+          "documentPath": "AWS-RunShellScript",
+          "documentParameters": {
+            "commands": ["touch /tmp/myfile"]
+          },
+          "documentType": "SSMDocument"
+        },
+        "name": "CreateFile",
+        "timeoutSeconds": 300
+      }
+EOF
+    },
+  ]
+
+  additional_ssm_bootstrap_step_count = "2"
+
+  additional_tags = [
+    {
+      key                 = "MyTag1"
+      value               = "Myvalue1"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "MyTag2"
+      value               = "Myvalue2"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "MyTag3"
+      value               = "Myvalue3"
+      propagate_at_launch = true
+    },
+  ]
+
+  encrypt_secondary_ebs_volume  = "False"
+  asg_wait_for_capacity_timeout = "10m"
+}
+
 module "ec2_asg_windows_with_codedeploy_test" {
   source = "../../module"
 
@@ -468,6 +590,125 @@ module "ec2_asg_windows_no_codedeploy_test" {
   scaling_max                = "2"
   cw_high_operator           = "GreaterThanThreshold"
   install_codedeploy_agent   = "False"
+
+  additional_ssm_bootstrap_list = [
+    {
+      ssm_add_step = <<EOF
+      {
+        "action": "aws:runDocument",
+        "inputs": {
+          "documentPath": "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-Install_Datadog",
+          "documentType": "SSMDocument"
+        },
+        "name": "InstallDataDog",
+        "timeoutSeconds": 300
+      }
+EOF
+    },
+    {
+      ssm_add_step = <<EOF
+      {
+        "action": "aws:runDocument",
+        "inputs": {
+          "documentPath": "AWS-RunPowerShellScript",
+          "documentParameters": {
+            "commands": ["echo $null >> C:\testfile"]
+          },
+          "documentType": "SSMDocument"
+        },
+        "name": "CreateFile",
+        "timeoutSeconds": 300
+      }
+EOF
+    },
+  ]
+
+  additional_ssm_bootstrap_step_count = "2"
+
+  additional_tags = [
+    {
+      key                 = "MyTag1"
+      value               = "Myvalue1"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "MyTag2"
+      value               = "Myvalue2"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "MyTag3"
+      value               = "Myvalue3"
+      propagate_at_launch = true
+    },
+  ]
+
+  encrypt_secondary_ebs_volume  = "False"
+  asg_wait_for_capacity_timeout = "10m"
+}
+
+module "ec2_asg_windows_no_scaleft_test" {
+  source = "../../module"
+
+  ec2_os    = "windows2016"
+  asg_count = "2"
+
+  #  load_balancer_names                    = ["${aws_elb.my_elb.name}"]
+  cw_low_operator = "LessThanThreshold"
+
+  instance_role_managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
+    "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole",
+    "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access",
+  ]
+
+  instance_role_managed_policy_arn_count = "2"
+  environment                            = "Development"
+  ssm_association_refresh_rate           = "rate(1 day)"
+  cw_scaling_metric                      = "CPUUtilization"
+  enable_ebs_optimization                = "False"
+  scaling_min                            = "1"
+  cloudwatch_log_retention               = "30"
+  secondary_ebs_volume_size              = "60"
+  rackspace_managed                      = true
+  cw_high_period                         = "60"
+  enable_scaling_notification            = true
+  subnets                                = ["${element(module.vpc.public_subnets, 0)}", "${element(module.vpc.public_subnets, 1)}"]
+  secondary_ebs_volume_iops              = "0"
+  ec2_scale_down_adjustment              = "1"
+  cw_low_period                          = "300"
+  key_pair                               = "CircleCI"
+  tenancy                                = "default"
+  backup_tag_value                       = "False"
+  ec2_scale_down_cool_down               = "60"
+  instance_type                          = "t2.micro"
+
+  # If ALB target groups are being used, one can specify ARNs like the commented line below.
+  #target_group_arns                      = ["${aws_lb_target_group.my_tg.arn}"]
+  secondary_ebs_volume_type = "gp2"
+
+  ec2_scale_up_adjustment    = "1"
+  cw_high_threshold          = "60"
+  scaling_notification_topic = "${module.sns_sqs.topic_arn}"
+  cw_low_threshold           = "30"
+  resource_name              = "${random_string.name_rstring.result}-ec2_asg_windows_no_scaleft"
+  ec2_scale_up_cool_down     = "60"
+  ssm_patching_group         = "Group1Patching"
+  health_check_grace_period  = "300"
+  security_group_list        = ["${module.vpc.default_sg}"]
+  perform_ssm_inventory_tag  = "True"
+  terminated_instances       = "30"
+  health_check_type          = "EC2"
+  cw_low_evaluations         = "3"
+  cw_high_evaluations        = "3"
+  primary_ebs_volume_iops    = "0"
+  detailed_monitoring        = "True"
+  primary_ebs_volume_type    = "gp2"
+  primary_ebs_volume_size    = "60"
+  scaling_max                = "2"
+  cw_high_operator           = "GreaterThanThreshold"
+  install_codedeploy_agent   = "False"
+  install_scaleft_agent      = "False"
 
   additional_ssm_bootstrap_list = [
     {

--- a/variables.tf
+++ b/variables.tf
@@ -61,6 +61,12 @@ variable "install_codedeploy_agent" {
   default     = false
 }
 
+variable "install_scaleft_agent" {
+  description = "Install scaleft agent on instance(s)? true or false"
+  type        = "string"
+  default     = true
+}
+
 variable "instance_type" {
   description = "EC2 Instance Type e.g. 't2.micro'"
   type        = "string"


### PR DESCRIPTION
* Add variable for making ScaleFT agent installation optional
* Remove ScaleFT from the main SSM bootstrap portion and make it an optional portion similar to the codedeploy segment
* Update readme with new variable description
* Update tests to assert a build with ScaleFT agent will run properly

##### If input variables or output variables have changed or has been added, have you updated the README?

Yes

##### Testing

* Manually setup module on a test account and verified that the ScaleFT installation step was not included in the SSM command doc steps when disabled, and included when enabled
* Ran test terraform files with new module

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
