### PR TITLE
Allow scaling actions to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module creates one or more autoscaling groups.
 
 ```HCL
 module "asg" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.0.21"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.0.25"
 
   ec2_os              = "amazon"
   subnets             = ["${module.vpc.private_subnets}"]
@@ -52,6 +52,7 @@ Using [aws-terraform-cloudwatch_alarm](https://github.com/rackspace-infrastructu
 | ec2\_scale\_up\_cool\_down | Time in seconds before any further trigger-related scaling can occur. | string | `"60"` | no |
 | enable\_ebs\_optimization | Use EBS Optimized? true or false | string | `"false"` | no |
 | enable\_rolling\_updates | Should this autoscaling group be targeted by the ASG Instance Replacement tool to ensure all instances are using thelatest launch configuration. | string | `"true"` | no |
+| enable\_scaling\_actions | Should this autoscaling group be configured with scaling alarms to manage the desired count.  Set this variable to false if another process will manage the desired count, such as EKS Cluster Autoscaler. | string | `"true"` | no |
 | enable\_scaling\_notification | true or false. If 'scaling_notification_topic' is set to a non-empty string, this must be set to true. Otherwise, set to false. This variable exists due to a terraform limitation with using count and computed values as conditionals | string | `"false"` | no |
 | encrypt\_secondary\_ebs\_volume | Encrypt secondary EBS Volume? true or false | string | `"false"` | no |
 | environment | Application environment for which this network is being created. Preferred value are Development, Integration, PreProduction, Production, QA, Staging, or Test | string | `"Development"` | no |

--- a/examples/basic_usage.tf
+++ b/examples/basic_usage.tf
@@ -50,7 +50,7 @@ module "sns_sqs" {
 }
 
 module "ec2_asg" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.0.21"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.0.25"
 
   ec2_os    = "centos7"
   asg_count = "2"

--- a/examples/custom_cw_config.tf
+++ b/examples/custom_cw_config.tf
@@ -50,7 +50,7 @@ module "sns_sqs" {
 }
 
 module "ec2_asg" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.0.21"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.0.25"
 
   ec2_os    = "centos7"
   asg_count = "2"

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@
  *
  * ```HCL
  * module "asg" {
- *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.0.21"
+ *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.0.25"
  *
  *   ec2_os              = "amazon"
  *   subnets             = ["${module.vpc.private_subnets}"]
@@ -581,7 +581,7 @@ resource "aws_launch_configuration" "launch_config_no_secondary_ebs" {
 }
 
 resource "aws_autoscaling_policy" "ec2_scale_up_policy" {
-  count = "${var.asg_count}"
+  count = "${var.enable_scaling_actions ? var.asg_count : 0}"
 
   name                   = "${join("-",compact(list("ec2_scale_up_policy", var.resource_name, format("%03d",count.index+1))))}"
   scaling_adjustment     = "${var.ec2_scale_up_adjustment}"
@@ -591,7 +591,7 @@ resource "aws_autoscaling_policy" "ec2_scale_up_policy" {
 }
 
 resource "aws_autoscaling_policy" "ec2_scale_down_policy" {
-  count = "${var.asg_count}"
+  count = "${var.enable_scaling_actions ? var.asg_count : 0}"
 
   name                   = "${join("-",compact(list("ec2_scale_down_policy", var.resource_name, format("%03d",count.index+1))))}"
   scaling_adjustment     = "${var.ec2_scale_down_adjustment > 0 ? 0 - var.ec2_scale_down_adjustment : var.ec2_scale_down_adjustment}"
@@ -696,7 +696,7 @@ module "group_terminating_instances" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "scale_alarm_high" {
-  count = "${var.asg_count}"
+  count = "${var.enable_scaling_actions ? var.asg_count : 0}"
 
   alarm_name          = "${join("-",compact(list("ScaleAlarmHigh", var.resource_name, format("%03d",count.index+1))))}"
   alarm_description   = "Scale-up if ${var.cw_scaling_metric} ${var.cw_high_operator} ${var.cw_high_threshold}% for ${var.cw_high_period} seconds ${var.cw_high_evaluations} times."
@@ -715,7 +715,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_alarm_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "scale_alarm_low" {
-  count = "${var.asg_count}"
+  count = "${var.enable_scaling_actions ? var.asg_count : 0}"
 
   alarm_name          = "${join("-",compact(list("ScaleAlarmLow", var.resource_name, format("%03d",count.index+1))))}"
   alarm_description   = "Scale-down if ${var.cw_scaling_metric} ${var.cw_low_operator} ${var.cw_low_threshold}% for ${var.cw_low_period} seconds ${var.cw_low_evaluations} times."

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -436,6 +436,7 @@ module "ec2_asg_windows_with_codedeploy_test" {
   secondary_ebs_volume_size              = "60"
   rackspace_managed                      = true
   cw_high_period                         = "60"
+  enable_scaling_actions                 = false
   enable_scaling_notification            = true
   subnets                                = ["${element(module.vpc.public_subnets, 0)}", "${element(module.vpc.public_subnets, 1)}"]
   secondary_ebs_volume_iops              = "0"
@@ -554,6 +555,7 @@ module "ec2_asg_windows_no_codedeploy_test" {
   secondary_ebs_volume_size              = "60"
   rackspace_managed                      = true
   cw_high_period                         = "60"
+  enable_scaling_actions                 = false
   enable_scaling_notification            = true
   subnets                                = ["${element(module.vpc.public_subnets, 0)}", "${element(module.vpc.public_subnets, 1)}"]
   secondary_ebs_volume_iops              = "0"
@@ -672,6 +674,7 @@ module "ec2_asg_windows_no_scaleft_test" {
   secondary_ebs_volume_size              = "60"
   rackspace_managed                      = true
   cw_high_period                         = "60"
+  enable_scaling_actions                 = false
   enable_scaling_notification            = true
   subnets                                = ["${element(module.vpc.public_subnets, 0)}", "${element(module.vpc.public_subnets, 1)}"]
   secondary_ebs_volume_iops              = "0"

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,12 @@ variable "enable_rolling_updates" {
   default     = true
 }
 
+variable "enable_scaling_actions" {
+  description = "Should this autoscaling group be configured with scaling alarms to manage the desired count.  Set this variable to false if another process will manage the desired count, such as EKS Cluster Autoscaler."
+  type        = "string"
+  default     = true
+}
+
 variable "environment" {
   description = "Application environment for which this network is being created. Preferred value are Development, Integration, PreProduction, Production, QA, Staging, or Test"
   type        = "string"


### PR DESCRIPTION
##### Corresponding Issue(s):
 - [MPCSUPENG-620](https://jira.rax.io/browse/MPCSUPENG-620)
fixes rackspace-infrastructure-automation/aws-terraform-internal#259

##### Summary of change(s):
Adds control variable to disable scaling actions.  Intended use is for environments where an external process, such as EKS Cluster Autoscaler will manage the scaling processes for an ASG.

##### Reason for Change(s):

- EKS Cluster Autoscaler implementation

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No - Existing CI tests were updated to verify the capability, which shows as a destructive action.  The default for the control variable will be for the scaling actions to remain.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

Yes, change made in order to fully implement EKS Cluster Autoscaling.

##### If input variables or output variables have changed or has been added, have you updated the README?

Yes, README.md was updated

##### Do examples need to be updated based on changes?

Yes, version pinnings in examples updated

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
