### PR TITLE
Remove Windows 2008 references since its EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ module "asg" {
   security_groups = ["${module.sg.private_web_security_group_id}"]
   subnets         = ["${module.vpc.private_subnets}"]
 }
-```Full working references are available at [examples](examples)
+```
+
+Full working references are available at [examples](examples)
 
 ## Other TF Modules Used
 
@@ -72,7 +74,7 @@ New variable `ssm_bootstrap_list` was added to allow setting the SSM association
 | cw\_low\_threshold | The value against which the specified statistic is compared. | `string` | `"30"` | no |
 | cw\_scaling\_metric | The metric to be used for scaling. | `string` | `"CPUUtilization"` | no |
 | detailed\_monitoring | Enable Detailed Monitoring? true or false | `bool` | `true` | no |
-| ec2\_os | Intended Operating System/Distribution of Instance. Valid inputs are: `amazon`, `amazon2`, `amazoneks`, `amazonecs`, `rhel6`, `rhel7`, `rhel8`, `centos6`, `centos7`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `windows2008`, `windows2012r2`, `windows2016`, `windows2019` | `string` | n/a | yes |
+| ec2\_os | Intended Operating System/Distribution of Instance. Valid inputs are: `amazon`, `amazon2`, `amazoneks`, `amazonecs`, `rhel6`, `rhel7`, `rhel8`, `centos6`, `centos7`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `windows2012r2`, `windows2016`, `windows2019` | `string` | n/a | yes |
 | ec2\_scale\_down\_adjustment | Number of EC2 instances to scale down by at a time. Positive numbers will be converted to negative. | `string` | `"-1"` | no |
 | ec2\_scale\_down\_cool\_down | Time in seconds before any further trigger-related scaling can occur. | `string` | `"60"` | no |
 | ec2\_scale\_up\_adjustment | Number of EC2 instances to scale up by at a time. | `string` | `"1"` | no |

--- a/main.tf
+++ b/main.tf
@@ -207,7 +207,6 @@ locals {
     ubuntu14      = "/dev/sdf"
     ubuntu16      = "/dev/sdf"
     ubuntu18      = "/dev/sdf"
-    windows2008   = "xvdf"
     windows2012r2 = "xvdf"
     windows2016   = "xvdf"
     windows2019   = "xvdf"
@@ -251,7 +250,6 @@ locals {
     ubuntu14      = "ubuntu_userdata.sh"
     ubuntu16      = "ubuntu_userdata.sh"
     ubuntu18      = "ubuntu_userdata.sh"
-    windows2008   = "windows_userdata.ps1"
     windows2012r2 = "windows_userdata.ps1"
     windows2016   = "windows_userdata.ps1"
     windows2019   = "windows_userdata.ps1"
@@ -270,7 +268,6 @@ locals {
     ubuntu14      = "099720109477"
     ubuntu16      = "099720109477"
     ubuntu18      = "099720109477"
-    windows2008   = "801119661308"
     windows2012r2 = "801119661308"
     windows2016   = "801119661308"
     windows2019   = "801119661308"
@@ -289,7 +286,6 @@ locals {
     ubuntu14      = "*ubuntu-trusty-14.04-amd64-server*"
     ubuntu16      = "*ubuntu-xenial-16.04-amd64-server*"
     ubuntu18      = "ubuntu/images/hvm-ssd/*ubuntu-bionic-18.04-amd64-server*"
-    windows2008   = "Windows_Server-2008-R2_SP1-English-64Bit-Base*"
     windows2012r2 = "Windows_Server-2012-R2_RTM-English-64Bit-Base*"
     windows2016   = "Windows_Server-2016-English-Full-Base*"
     windows2019   = "Windows_Server-2019-English-Full-Base*"
@@ -307,7 +303,6 @@ locals {
     ubuntu14      = []
     ubuntu16      = []
     ubuntu18      = []
-    windows2008   = []
     windows2012r2 = []
     windows2016   = []
     windows2019   = []

--- a/variables.tf
+++ b/variables.tf
@@ -101,7 +101,7 @@ variable "detailed_monitoring" {
 }
 
 variable "ec2_os" {
-  description = "Intended Operating System/Distribution of Instance. Valid inputs are: `amazon`, `amazon2`, `amazoneks`, `amazonecs`, `rhel6`, `rhel7`, `rhel8`, `centos6`, `centos7`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `windows2008`, `windows2012r2`, `windows2016`, `windows2019`"
+  description = "Intended Operating System/Distribution of Instance. Valid inputs are: `amazon`, `amazon2`, `amazoneks`, `amazonecs`, `rhel6`, `rhel7`, `rhel8`, `centos6`, `centos7`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `windows2012r2`, `windows2016`, `windows2019`"
   type        = string
 }
 


### PR DESCRIPTION
##### Corresponding Issue(s):
https://jira.rax.io/browse/MPCSUPENG-917

##### Summary of change(s):
- Remove all Windows 2008 references. 
##### Reason for Change(s):

maintenance to keep pace with supported  OSes.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No. If you are using Windows 2008 then you  should not upgrade to this version of the module.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

No.
##### If input variables or output variables have changed or has been added, have you updated the README?

Yes.

##### Do examples need to be updated based on changes?
No.
