### PR TITLE
Remove CF specific IAM permission from instance policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module creates one or more autoscaling groups.
 
 ```HCL
 module "asg" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.12.1"
 
   ec2_os          = "amazon"
   image_id        = "${var.image_id}"
@@ -20,7 +20,7 @@ Full working references are available at [examples](examples)
 
 ## Other TF Modules Used
 
-Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm) to create the following CloudWatch Alarms:  
+Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm) to create the following CloudWatch Alarms:
 - group\_terminating\_instances
 
 ## Terraform 0.12 upgrade
@@ -32,7 +32,7 @@ made when upgrading from a previous release to version 0.12.0 or higher.
 
 The following module variables were updated to better meet current Rackspace style guides:
 
-- `security_group_list` -> `security_groups`  
+- `security_group_list` -> `security_groups`
 - `resource_name` -> `name`
 
 The following variables are no longer neccessary and were removed

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@
  *
  * ```HCL
  * module "asg" {
- *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.12.0"
+ *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.12.1"
  *
  *   ec2_os          = "amazon"
  *   image_id        = "${var.image_id}"
@@ -382,11 +382,6 @@ data "aws_iam_policy_document" "mod_ec2_assume_role_policy_doc" {
 }
 
 data "aws_iam_policy_document" "mod_ec2_instance_role_policies" {
-  statement {
-    actions   = ["cloudformation:Describe"]
-    effect    = "Allow"
-    resources = ["*"]
-  }
 
   statement {
     effect    = "Allow"


### PR DESCRIPTION
##### Corresponding Issue(s):
- https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/235
- https://jira.rax.io/browse/MPCSUPENG-344


##### Summary of change(s):
removed `cloudformation:Describe*`  from instance policy
##### Reason for Change(s):
- least privilege for the win

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
no
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
no
##### If input variables or output variables have changed or has been added, have you updated the README?
no
##### Do examples need to be updated based on changes?
no
