### PR TITLE
Update inline IAM policy for EC2 instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module creates one or more autoscaling groups.
 
 ```HCL
 module "asg" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.12.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.12.2"
 
   ec2_os          = "amazon"
   image_id        = "${var.image_id}"

--- a/examples/basic_usage.tf
+++ b/examples/basic_usage.tf
@@ -8,7 +8,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.10"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.1"
 
   name = "EC2-ASG-BaseNetwork-Test1"
 }
@@ -27,25 +27,25 @@ data "aws_ami" "amazon_centos_7" {
 
 resource "random_string" "sqs_rstring" {
   length  = 18
-  upper   = false
   special = false
+  upper   = false
 }
 
-resource "aws_sqs_queue" "ec2-asg-test_sqs" {
+resource "aws_sqs_queue" "ec2_asg_test_sqs" {
   name = "${random_string.sqs_rstring.result}-my-example-queue"
 }
 
 module "sns_sqs" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns?ref=v0.12.1"
 
   create_subscription_1 = true
+  endpoint_1            = aws_sqs_queue.ec2_asg_test_sqs.arn
   name                  = "${random_string.sqs_rstring.result}-ec2-asg-test-topic"
   protocol_1            = "sqs"
-  endpoint_1            = aws_sqs_queue.ec2-asg-test_sqs.arn
 }
 
 module "ec2_asg" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.12.2"
 
   asg_count                              = "2"
   asg_wait_for_capacity_timeout          = "10m"

--- a/examples/custom_cw_config.tf
+++ b/examples/custom_cw_config.tf
@@ -8,7 +8,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.1"
 
   name = "EC2-ASG-BaseNetwork-Test1"
 }
@@ -31,21 +31,21 @@ resource "random_string" "sqs_rstring" {
   upper   = false
 }
 
-resource "aws_sqs_queue" "ec2-asg-test_sqs" {
+resource "aws_sqs_queue" "ec2_asg_test_sqs" {
   name = "${random_string.sqs_rstring.result}-my-example-queue"
 }
 
 module "sns_sqs" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns?ref=v0.12.1"
 
   create_subscription_1 = true
-  endpoint_1            = aws_sqs_queue.ec2-asg-test_sqs.arn
+  endpoint_1            = aws_sqs_queue.ec2_asg_test_sqs.arn
   name                  = "${random_string.sqs_rstring.result}-ec2-asg-test-topic"
   protocol_1            = "sqs"
 }
 
 module "ec2_asg" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.12.2"
 
   asg_count                              = "2"
   asg_wait_for_capacity_timeout          = "10m"

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@
  *
  * ```HCL
  * module "asg" {
- *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.12.1"
+ *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.12.2"
  *
  *   ec2_os          = "amazon"
  *   image_id        = "${var.image_id}"
@@ -390,6 +390,7 @@ data "aws_iam_policy_document" "mod_ec2_instance_role_policies" {
     actions = [
       "ssm:CreateAssociation",
       "ssm:DescribeInstanceInformation",
+      "ssm:GetParameter",
     ]
   }
 
@@ -406,35 +407,23 @@ data "aws_iam_policy_document" "mod_ec2_instance_role_policies" {
       "logs:CreateLogStream",
       "logs:DescribeLogStreams",
       "logs:PutLogEvents",
-      "ssm:GetParameter",
     ]
   }
 
   statement {
     effect    = "Allow"
-    resources = ["*"]
+    resources = ["arn:aws:s3:::rackspace-*/*"]
 
     actions = [
-      "s3:PutObject",
-      "s3:GetObject",
-      "s3:GetEncryptionConfiguration",
       "s3:AbortMultipartUpload",
-      "s3:ListMultipartUploadParts",
+      "s3:GetBucketLocation",
+      "s3:GetEncryptionConfiguration",
+      "s3:GetObject",
       "s3:ListBucket",
       "s3:ListBucketMultipartUploads",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
     ]
-  }
-
-  statement {
-    actions   = ["s3:GetBucketLocation"]
-    effect    = "Allow"
-    resources = ["*"]
-  }
-
-  statement {
-    actions   = ["ec2:DescribeTags"]
-    effect    = "Allow"
-    resources = ["*"]
   }
 }
 

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -31,15 +31,15 @@ module "vpc" {
   name = "${random_string.name_rstring.result}-ec2-asg-basenetwork-test1"
 }
 
-resource "aws_sqs_queue" "ec2-asg-test_sqs" {
-  name = "${random_string.sqs_rstring.result}-my-example-queue"
+resource "aws_sqs_queue" "ec2_asg_test_sqs" {
+  name = "${random_string.sqs_rstring.result}-example-queue"
 }
 
 module "sns" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns?ref=master"
 
   create_subscription_1 = true
-  endpoint_1            = aws_sqs_queue.ec2-asg-test_sqs.arn
+  endpoint_1            = aws_sqs_queue.ec2_asg_test_sqs.arn
   name                  = "${random_string.sqs_rstring.result}-test-topic"
   protocol_1            = "sqs"
 }


### PR DESCRIPTION
##### Corresponding Issue(s):
 - [MPCSUPENG-962](https://jira.rax.io/browse/MPCSUPENG-962)

##### Summary of change(s):
Updates default inline IAM policy for EC2 instances to only allow access to buckets beginning with `rackspace-`. This will allow access to predetermined S3 files, and if additional S3 locations are required, a managed policy can be assigned to the instances IAM role via existing parameters.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No.  CI test shows replacement of SNS resources.  These are not related to module change, and were updated to satisfy linting requirements.
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
No variable or output changes.  Version pinning in readme and examples updated.
##### Do examples need to be updated based on changes?
Version pinning in readme and examples updated.
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
