### PR TITLE
Enable Alarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ New variable `ssm_bootstrap_list` was added to allow setting the SSM association
 | ec2\_scale\_down\_cool\_down | Time in seconds before any further trigger-related scaling can occur. | `string` | `"60"` | no |
 | ec2\_scale\_up\_adjustment | Number of EC2 instances to scale up by at a time. | `string` | `"1"` | no |
 | ec2\_scale\_up\_cool\_down | Time in seconds before any further trigger-related scaling can occur. | `string` | `"60"` | no |
+| enable\_all\_asg\_metrics | Should all ASG metrics be collected? If yes and not `suppress_all_asg_metrics` then all metrics are collected.  Otherwise collects Terminating metrics only, required for alarms unless `suppress_all_asg_metrics then no metrics are collected`. | `bool` | `false` | no |
 | enable\_ebs\_optimization | Use EBS Optimized? true or false | `bool` | `false` | no |
 | enable\_rolling\_updates | Should this autoscaling group be targeted by the ASG Instance Replacement tool to ensure all instances are using thelatest launch configuration. | `bool` | `true` | no |
 | enable\_scaling\_actions | Should this autoscaling group be configured with scaling alarms to manage the desired count.  Set this variable to false if another process will manage the desired count, such as EKS Cluster Autoscaler. | `bool` | `true` | no |
@@ -120,6 +121,7 @@ New variable `ssm_bootstrap_list` was added to allow setting the SSM association
 | ssm\_bootstrap\_list | A list of objects consisting of actions, to be appended to SSM associations. Please see usage.tf.example in this repo for examples. | `any` | `[]` | no |
 | ssm\_patching\_group | Group ID to be used by System Manager for Patching | `string` | `""` | no |
 | subnets | List of subnets for Application. e.g. ['subnet-8da92df7', 'subnet-9e5dc5f6', 'subnet-497eaf33'] | `list(string)` | n/a | yes |
+| suppress\_all\_asg\_metrics | Boolean parameter controlling if ASG group level metrics should be suppressed.  This is to ensure compatibility with previous deployments and if enabled overrides `enable_all_asg_metrics` so no metrics are collected. | `bool` | `true` | no |
 | tags | A map of tags to apply to all resources.  These tags will all be propagated to ASG instances and set on all other resources. | `map(string)` | `{}` | no |
 | tags\_asg | A map of tags to apply to the ASG itself.  These tags will not be propagated to ASG instances or set on any other resources. | `map(string)` | `{}` | no |
 | target\_group\_arns | A list of Amazon Resource Names (ARN) of target groups to associate with the Auto Scaling group. | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ New variable `ssm_bootstrap_list` was added to allow setting the SSM association
 | ec2\_scale\_down\_cool\_down | Time in seconds before any further trigger-related scaling can occur. | `string` | `"60"` | no |
 | ec2\_scale\_up\_adjustment | Number of EC2 instances to scale up by at a time. | `string` | `"1"` | no |
 | ec2\_scale\_up\_cool\_down | Time in seconds before any further trigger-related scaling can occur. | `string` | `"60"` | no |
-| enable\_all\_asg\_metrics | Should all ASG metrics be collected? If yes and not `suppress_all_asg_metrics` then all metrics are collected.  Otherwise collects Terminating metrics only, required for alarms unless `suppress_all_asg_metrics then no metrics are collected`. | `bool` | `false` | no |
 | enable\_ebs\_optimization | Use EBS Optimized? true or false | `bool` | `false` | no |
 | enable\_rolling\_updates | Should this autoscaling group be targeted by the ASG Instance Replacement tool to ensure all instances are using thelatest launch configuration. | `bool` | `true` | no |
 | enable\_scaling\_actions | Should this autoscaling group be configured with scaling alarms to manage the desired count.  Set this variable to false if another process will manage the desired count, such as EKS Cluster Autoscaler. | `bool` | `true` | no |
 | enable\_scaling\_notification | true or false. If 'scaling\_notification\_topic' is set to a non-empty string, this must be set to true. Otherwise, set to false. This variable exists due to a terraform limitation with using count and computed values as conditionals | `bool` | `false` | no |
+| enabled\_asg\_metrics | List of ASG metrics desired.  This can only contain the following values: `GroupDesiredCapacity`, `GroupInServiceCapacity`, `GroupPendingCapacity`, `GroupMinSize`, `GroupMaxSize`, `GroupInServiceInstances`, `GroupPendingInstances`, `GroupStandbyInstances`, `GroupStandbyCapacity`, `GroupTerminatingCapacity`, `GroupTerminatingInstances`, `GroupTotalCapacity`, `GroupTotalInstances`. | `list(string)` | `[]` | no |
 | encrypt\_primary\_ebs\_volume | Encrypt root EBS Volume? true or false | `bool` | `false` | no |
 | encrypt\_secondary\_ebs\_volume | Encrypt secondary EBS Volume? true or false | `bool` | `false` | no |
 | environment | Application environment for which this network is being created. Preferred value are Development, Integration, PreProduction, Production, QA, Staging, or Test | `string` | `"Development"` | no |
@@ -121,7 +121,6 @@ New variable `ssm_bootstrap_list` was added to allow setting the SSM association
 | ssm\_bootstrap\_list | A list of objects consisting of actions, to be appended to SSM associations. Please see usage.tf.example in this repo for examples. | `any` | `[]` | no |
 | ssm\_patching\_group | Group ID to be used by System Manager for Patching | `string` | `""` | no |
 | subnets | List of subnets for Application. e.g. ['subnet-8da92df7', 'subnet-9e5dc5f6', 'subnet-497eaf33'] | `list(string)` | n/a | yes |
-| suppress\_all\_asg\_metrics | Boolean parameter controlling if ASG group level metrics should be suppressed.  This is to ensure compatibility with previous deployments and if enabled overrides `enable_all_asg_metrics` so no metrics are collected. | `bool` | `true` | no |
 | tags | A map of tags to apply to all resources.  These tags will all be propagated to ASG instances and set on all other resources. | `map(string)` | `{}` | no |
 | tags\_asg | A map of tags to apply to the ASG itself.  These tags will not be propagated to ASG instances or set on any other resources. | `map(string)` | `{}` | no |
 | target\_group\_arns | A list of Amazon Resource Names (ARN) of target groups to associate with the Auto Scaling group. | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -580,7 +580,7 @@ resource "aws_autoscaling_policy" "ec2_scale_down_policy" {
 resource "aws_autoscaling_group" "autoscalegrp" {
   count = var.asg_count
 
-  enable_metrics            = var.suppress_all_asg_metrics ? null : local.asg_metrics
+  enabled_metrics           = var.suppress_all_asg_metrics ? null : local.asg_metrics
   health_check_grace_period = var.health_check_grace_period
   health_check_type         = var.health_check_type
   load_balancers            = var.load_balancer_names

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ locals {
   ec2_os_windows             = substr(local.ec2_os, 0, local.ec2_os_windows_length_test) == "windows" ? true : false
 
   metrics_permitted = ["GroupDesiredCapacity", "GroupInServiceCapacity", "GroupPendingCapacity", "GroupMinSize", "GroupMaxSize", "GroupInServiceInstances", "GroupPendingInstances", "GroupStandbyInstances", "GroupStandbyCapacity", "GroupTerminatingCapacity", "GroupTerminatingInstances", "GroupTotalCapacity", "GroupTotalInstances"]
-  asg_metrics       = var.enable_all_asg_metrics ? local.metrics_permitted: ["GroupTerminatingInstances"]
+  asg_metrics       = var.enable_all_asg_metrics ? local.metrics_permitted : ["GroupTerminatingInstances"]
 
   cw_config_parameter_name = "CWAgent-${var.name}"
 
@@ -580,7 +580,7 @@ resource "aws_autoscaling_policy" "ec2_scale_down_policy" {
 resource "aws_autoscaling_group" "autoscalegrp" {
   count = var.asg_count
 
-  enable_metrics            = var.suppress_all_asg_metrics ? null: local.asg_metrics
+  enable_metrics            = var.suppress_all_asg_metrics ? null : local.asg_metrics
   health_check_grace_period = var.health_check_grace_period
   health_check_type         = var.health_check_type
   load_balancers            = var.load_balancer_names

--- a/main.tf
+++ b/main.tf
@@ -61,8 +61,8 @@ locals {
   ec2_os_windows_length_test = length(local.ec2_os) >= 7 ? 7 : length(local.ec2_os)
   ec2_os_windows             = substr(local.ec2_os, 0, local.ec2_os_windows_length_test) == "windows" ? true : false
 
-  metrics_permitted = ["GroupDesiredCapacity", "GroupInServiceCapacity", "GroupPendingCapacity", "GroupMinSize", "GroupMaxSize", "GroupInServiceInstances", "GroupPendingInstances", "GroupStandbyInstances", "GroupStandbyCapacity", "GroupTerminatingCapacity", "GroupTerminatingInstances", "GroupTotalCapacity", "GroupTotalInstances"]
-  asg_metrics       = var.enable_all_asg_metrics ? local.metrics_permitted : ["GroupTerminatingInstances"]
+  # Enforce metrics needed for CW
+  asg_metrics = distinct(concat(var.enabled_asg_metrics, ["GroupTerminatingInstances"]))
 
   cw_config_parameter_name = "CWAgent-${var.name}"
 
@@ -580,7 +580,7 @@ resource "aws_autoscaling_policy" "ec2_scale_down_policy" {
 resource "aws_autoscaling_group" "autoscalegrp" {
   count = var.asg_count
 
-  enabled_metrics           = var.suppress_all_asg_metrics ? null : local.asg_metrics
+  enabled_metrics           = local.asg_metrics
   health_check_grace_period = var.health_check_grace_period
   health_check_type         = var.health_check_type
   load_balancers            = var.load_balancer_names

--- a/variables.tf
+++ b/variables.tf
@@ -129,6 +129,12 @@ variable "ec2_scale_up_cool_down" {
   default     = "60"
 }
 
+variable "enable_all_asg_metrics" {
+  description = "Should all ASG metrics be collected? If yes and not `suppress_all_asg_metrics` then all metrics are collected.  Otherwise collects Terminating metrics only, required for alarms unless `suppress_all_asg_metrics then no metrics are collected`."
+  type        = bool
+  default     = false
+}
+
 variable "enable_ebs_optimization" {
   description = "Use EBS Optimized? true or false"
   type        = bool
@@ -370,6 +376,12 @@ variable "ssm_patching_group" {
 variable "subnets" {
   description = "List of subnets for Application. e.g. ['subnet-8da92df7', 'subnet-9e5dc5f6', 'subnet-497eaf33']"
   type        = list(string)
+}
+
+variable "suppress_all_asg_metrics" {
+  description = "Boolean parameter controlling if ASG group level metrics should be suppressed.  This is to ensure compatibility with previous deployments and if enabled overrides `enable_all_asg_metrics` so no metrics are collected."
+  type        = bool
+  default     = true
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -129,12 +129,6 @@ variable "ec2_scale_up_cool_down" {
   default     = "60"
 }
 
-variable "enable_all_asg_metrics" {
-  description = "Should all ASG metrics be collected? If yes and not `suppress_all_asg_metrics` then all metrics are collected.  Otherwise collects Terminating metrics only, required for alarms unless `suppress_all_asg_metrics then no metrics are collected`."
-  type        = bool
-  default     = false
-}
-
 variable "enable_ebs_optimization" {
   description = "Use EBS Optimized? true or false"
   type        = bool
@@ -157,6 +151,12 @@ variable "enable_scaling_notification" {
   description = "true or false. If 'scaling_notification_topic' is set to a non-empty string, this must be set to true. Otherwise, set to false. This variable exists due to a terraform limitation with using count and computed values as conditionals"
   type        = bool
   default     = false
+}
+
+variable "enabled_asg_metrics" {
+  description = "List of ASG metrics desired.  This can only contain the following values: `GroupDesiredCapacity`, `GroupInServiceCapacity`, `GroupPendingCapacity`, `GroupMinSize`, `GroupMaxSize`, `GroupInServiceInstances`, `GroupPendingInstances`, `GroupStandbyInstances`, `GroupStandbyCapacity`, `GroupTerminatingCapacity`, `GroupTerminatingInstances`, `GroupTotalCapacity`, `GroupTotalInstances`."
+  type        = list(string)
+  default     = []
 }
 
 variable "encrypt_primary_ebs_volume" {
@@ -376,12 +376,6 @@ variable "ssm_patching_group" {
 variable "subnets" {
   description = "List of subnets for Application. e.g. ['subnet-8da92df7', 'subnet-9e5dc5f6', 'subnet-497eaf33']"
   type        = list(string)
-}
-
-variable "suppress_all_asg_metrics" {
-  description = "Boolean parameter controlling if ASG group level metrics should be suppressed.  This is to ensure compatibility with previous deployments and if enabled overrides `enable_all_asg_metrics` so no metrics are collected."
-  type        = bool
-  default     = true
 }
 
 variable "tags" {


### PR DESCRIPTION
##### Corresponding Issue(s):
 - PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section

##### Summary of change(s):
Change name to remove `}` and enabled metrics required for alarm to gather data.  Currently alarms are in "Insufficient Data" as metrics are not enabled.

##### Reason for Change(s):

- If a bug, describe error scenario, including expected behavior and actual behavior.
CW Alarm for Terminating Instances shows as Insufficient Data due to Metrics it uses not being enabled.  This will enable them so that the alarm can alert when a certain number of instances have terminated within 6h.

- If an enhancement, describe the use case and the perceived benefit(s).

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No - added suppression variable to enforce legacy mode where alarm does not work / no changes.  By default this is enabled.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

##### If input variables or output variables have changed or has been added, have you updated the README?
Yes

##### Do examples need to be updated based on changes?
Should not be needed as it is fixing a bug in current functionality.

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
