### PR TITLE
Enable customer notifications in parallel with rackspace notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ New variable `ssm_bootstrap_list` was added to allow setting the SSM association
 | asg\_wait\_for\_capacity\_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. | `string` | `"10m"` | no |
 | backup\_tag\_value | Value of the 'Backup' tag, used to assign te EBSSnapper configuration | `string` | `"False"` | no |
 | cloudwatch\_log\_retention | The number of days to retain Cloudwatch Logs for this instance. | `string` | `"30"` | no |
+| custom\_cw\_agent\_config\_ssm\_param | SSM Parameter Store name that contains a custom CloudWatch agent configuration that you would like to use as an alternative to the default provided. | `string` | `""` | no |
 | customer\_alarms\_cleared | Specifies whether alarms will notify customers when returning to an OK status. | `bool` | `false` | no |
 | customer\_alarms\_enabled | Specifies whether alarms will notify customers.  Automatically enabled if rackspace\_managed is set to false | `bool` | `false` | no |
-| custom\_cw\_agent\_config\_ssm\_param | SSM Parameter Store name that contains a custom CloudWatch agent configuration that you would like to use as an alternative to the default provided. | `string` | `""` | no |
 | cw\_high\_evaluations | The number of periods over which data is compared to the specified threshold. | `string` | `"3"` | no |
 | cw\_high\_operator | Math operator used by CloudWatch for alarms and triggers. | `string` | `"GreaterThanThreshold"` | no |
 | cw\_high\_period | Time the specified statistic is applied. Must be in seconds that is also a multiple of 60. | `string` | `"60"` | no |

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ New variable `ssm_bootstrap_list` was added to allow setting the SSM association
 | asg\_wait\_for\_capacity\_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. | `string` | `"10m"` | no |
 | backup\_tag\_value | Value of the 'Backup' tag, used to assign te EBSSnapper configuration | `string` | `"False"` | no |
 | cloudwatch\_log\_retention | The number of days to retain Cloudwatch Logs for this instance. | `string` | `"30"` | no |
+| customer\_alarms\_cleared | Specifies whether alarms will notify customers when returning to an OK status. | `bool` | `false` | no |
+| customer\_alarms\_enabled | Specifies whether alarms will notify customers.  Automatically enabled if rackspace\_managed is set to false | `bool` | `false` | no |
 | custom\_cw\_agent\_config\_ssm\_param | SSM Parameter Store name that contains a custom CloudWatch agent configuration that you would like to use as an alternative to the default provided. | `string` | `""` | no |
 | cw\_high\_evaluations | The number of periods over which data is compared to the specified threshold. | `string` | `"3"` | no |
 | cw\_high\_operator | Math operator used by CloudWatch for alarms and triggers. | `string` | `"GreaterThanThreshold"` | no |

--- a/main.tf
+++ b/main.tf
@@ -703,6 +703,8 @@ module "group_terminating_instances" {
   alarm_description        = "Over ${var.terminated_instances} instances terminated in last 6 hours, generating ticket to investigate."
   alarm_name               = "${var.name}-GroupTerminatingInstances"
   comparison_operator      = "GreaterThanThreshold"
+  customer_alarms_cleared  = var.customer_alarms_cleared
+  customer_alarms_enabled  = var.customer_alarms_enabled
   dimensions               = data.null_data_source.alarm_dimensions.*.outputs
   evaluation_periods       = 1
   metric_name              = "GroupTerminatingInstances"

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,18 @@ variable "cloudwatch_log_retention" {
   default     = "30"
 }
 
+variable "customer_alarms_cleared" {
+  description = "Specifies whether alarms will notify customers when returning to an OK status."
+  type        = bool
+  default     = false
+}
+
+variable "customer_alarms_enabled" {
+  description = "Specifies whether alarms will notify customers.  Automatically enabled if rackspace_managed is set to false"
+  type        = bool
+  default     = false
+}
+
 variable "custom_cw_agent_config_ssm_param" {
   description = "SSM Parameter Store name that contains a custom CloudWatch agent configuration that you would like to use as an alternative to the default provided."
   type        = string


### PR DESCRIPTION
##### Corresponding Issue(s):
 - PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section

##### Summary of change(s):

This change permits customer notifications for EC2 scaling group alarms to be enabled explicitly and independently of the `rackspace_managed` setting.

##### Reason for Change(s):

The EC2 ASG module allows a customer/additional `notification_topic` to be specified for notifying of Cloudwatch alarms, but this is used only when `rackspace_managed` is set to `false`. In other words, either the customer or Rackspace is notified, but not both.

This change allows both Rackspace and a customer to receive notifications. This more accurately reflects both past and current support offerings (i.e. solely managed by Rackspace, managed in partnership with customer).

- If a bug, describe error scenario, including expected behavior and actual behavior.

- If an enhancement, describe the use case and the perceived benefit(s).

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No resource destruction or replacement will be triggered by this change. The PR preserves the previous behavior. Enabling the "new" behaviour requires explicit changes in the ASG module usage; modifying `alarm_actions` and/or `ok_actions` in a Terraform `aws_cloudwatch_metric_alarm` is an in-place change.


##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

Not directly; the PR brings this module somewhat more in line with other Rackspace Terraform modules
such as `aws-terraform-rds` which hard-codes `customer_alarms_enable = true`. When working on this PR, I considered using the same approach but reached the conclusion that hard-coding either way was not justified (inflexible, requires forks to adapt).

##### If input variables or output variables have changed or has been added, have you updated the README?

Yes.

##### Do examples need to be updated based on changes?

No 

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
