### PR TITLE
Remove EOL Amazon Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This module creates one or more autoscaling groups.
 
 ```HCL
 module "asg" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.12.12"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.12.16"
 
-  ec2_os          = "amazon"
+  ec2_os          = "amazon2"
   name            = "my_asg"
   security_groups = [module.sg.private_web_security_group_id]
   subnets         = module.vpc.private_subnets
@@ -115,7 +115,7 @@ New variable `ssm_bootstrap_list` was added to allow setting the SSM association
 | cw\_scaling\_metric | The metric to be used for scaling. | `string` | `"CPUUtilization"` | no |
 | detailed\_monitoring | Enable Detailed Monitoring? true or false | `bool` | `true` | no |
 | disable\_scale\_in | Disable scale in to create only a scale-out policy in Target Tracking Policy. | `bool` | `false` | no |
-| ec2\_os | Intended Operating System/Distribution of Instance. Valid inputs are: `amazon`, `amazon2`, `amazoneks`, `amazonecs`, `rhel7`, `rhel8`, `centos7`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `ubuntu20`, `windows2012r2`, `windows2016`, `windows2019` | `string` | n/a | yes |
+| ec2\_os | Intended Operating System/Distribution of Instance. Valid inputs are: `amazon2`, `amazoneks`, `amazonecs`, `rhel7`, `rhel8`, `centos7`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `ubuntu20`, `windows2012r2`, `windows2016`, `windows2019` | `string` | n/a | yes |
 | ec2\_scale\_down\_adjustment | Number of EC2 instances to scale down by at a time. Positive numbers will be converted to negative. | `string` | `"-1"` | no |
 | ec2\_scale\_down\_cool\_down | Time in seconds before any further trigger-related scaling can occur. | `string` | `"60"` | no |
 | ec2\_scale\_up\_adjustment | Number of EC2 instances to scale up by at a time. | `string` | `"1"` | no |

--- a/main.tf
+++ b/main.tf
@@ -7,9 +7,9 @@
  *
  * ```HCL
  * module "asg" {
- *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.12.12"
+ *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.12.16"
  *
- *   ec2_os          = "amazon"
+ *   ec2_os          = "amazon2"
  *   name            = "my_asg"
  *   security_groups = [module.sg.private_web_security_group_id]
  *   subnets         = module.vpc.private_subnets
@@ -213,7 +213,6 @@ locals {
   }
 
   diagnostic_packages = {
-    amazon    = local.defaults["diagnostic_packages"]["amazon"]
     amazon2   = local.defaults["diagnostic_packages"]["amazon"]
     amazoneks = local.defaults["diagnostic_packages"]["amazon"]
     amazonecs = local.defaults["diagnostic_packages"]["amazon"]
@@ -228,7 +227,6 @@ locals {
   }
 
   ebs_device_map = {
-    amazon        = "/dev/sdf"
     amazon2       = "/dev/sdf"
     amazoneks     = "/dev/sdf"
     amazonecs     = "/dev/xvdcz"
@@ -271,7 +269,6 @@ locals {
   }
 
   user_data_map = {
-    amazon        = "amazon_linux_userdata.sh"
     amazon2       = "amazon_linux_userdata.sh"
     amazonecs     = "amazon_linux_userdata.sh"
     amazoneks     = "amazon_linux_userdata.sh"
@@ -289,7 +286,6 @@ locals {
   }
 
   ami_owner_mapping = {
-    amazon        = "137112412989"
     amazon2       = "137112412989"
     amazonecs     = "591542846629"
     amazoneks     = "602401143452"
@@ -307,7 +303,6 @@ locals {
   }
 
   ami_name_mapping = {
-    amazon        = "amzn-ami-hvm-2018.03.0.*gp2"
     amazon2       = "amzn2-ami-hvm-2.0.*-ebs"
     amazonecs     = "amzn2-ami-ecs-hvm-2*-x86_64-ebs"
     amazoneks     = "amazon-eks-node-*"
@@ -326,7 +321,6 @@ locals {
 
   # Any custom AMI filters for a given OS can be added in this mapping
   image_filter = {
-    amazon        = []
     amazon2       = []
     amazonecs     = []
     amazoneks     = []

--- a/text/amazon_linux_userdata.sh
+++ b/text/amazon_linux_userdata.sh
@@ -20,11 +20,6 @@ else
         if [[ $ssm_running == "0" ]]; then
             systemctl start amazon-ssm-agent
         fi
-    else
-        # Amazon Linux
-        if [[ $ssm_running == "0" ]]; then
-            start amazon-ssm-agent
-        fi
     fi
 fi
 

--- a/variables.tf
+++ b/variables.tf
@@ -125,7 +125,7 @@ variable "disable_scale_in" {
 }
 
 variable "ec2_os" {
-  description = "Intended Operating System/Distribution of Instance. Valid inputs are: `amazon`, `amazon2`, `amazoneks`, `amazonecs`, `rhel7`, `rhel8`, `centos7`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `ubuntu20`, `windows2012r2`, `windows2016`, `windows2019`"
+  description = "Intended Operating System/Distribution of Instance. Valid inputs are: `amazon2`, `amazoneks`, `amazonecs`, `rhel7`, `rhel8`, `centos7`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `ubuntu20`, `windows2012r2`, `windows2016`, `windows2019`"
   type        = string
 }
 


### PR DESCRIPTION
##### Corresponding Issue(s):
 - MPCSUPENG-2839
##### Summary of change(s):

Removing references to Amazon Linux for being EOL.

##### Reason for Change(s):

- Amazon Linux ended its standard support on December 31, 2020

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No. If you are using Amazon Linux then you should not upgrade to this version of the module.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

No.

##### If input variables or output variables have changed or has been added, have you updated the README?

Yes.

##### Do examples need to be updated based on changes?

No.

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
