### PR TITLE
Remove EOL Amazon Linux for tf_v0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This module creates one or more autoscaling groups.
 module "asg" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.0.26"
 
-  ec2_os              = "amazon"
+  ec2_os              = "amazon2"
   subnets             = ["${module.vpc.private_subnets}"]
   image_id            = "${var.image_id}"
   resource_name       = "my_asg"
@@ -92,7 +92,7 @@ No requirements.
 | cw\_low\_threshold | The value against which the specified statistic is compared. | `string` | `"30"` | no |
 | cw\_scaling\_metric | The metric to be used for scaling. | `string` | `"CPUUtilization"` | no |
 | detailed\_monitoring | Enable Detailed Monitoring? true or false | `string` | `true` | no |
-| ec2\_os | Intended Operating System/Distribution of Instance. Valid inputs are: `amazon`, `amazon2`, `amazoneks`, `amazonecs`, `rhel7`, `rhel8`, `centos7`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `ubuntu20`, `windows2012r2`, `windows2016`, `windows2019` | `string` | n/a | yes |
+| ec2\_os | Intended Operating System/Distribution of Instance. Valid inputs are: `amazon2`, `amazoneks`, `amazonecs`, `rhel7`, `rhel8`, `centos7`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `ubuntu20`, `windows2012r2`, `windows2016`, `windows2019` | `string` | n/a | yes |
 | ec2\_scale\_down\_adjustment | Number of EC2 instances to scale down by at a time. Positive numbers will be converted to negative. | `string` | `"-1"` | no |
 | ec2\_scale\_down\_cool\_down | Time in seconds before any further trigger-related scaling can occur. | `string` | `"60"` | no |
 | ec2\_scale\_up\_adjustment | Number of EC2 instances to scale up by at a time. | `string` | `"1"` | no |

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  * module "asg" {
  *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=v0.0.26"
  *
- *   ec2_os              = "amazon"
+ *   ec2_os              = "amazon2"
  *   subnets             = ["${module.vpc.private_subnets}"]
  *   image_id            = "${var.image_id}"
  *   resource_name       = "my_asg"
@@ -166,7 +166,6 @@ EOF
   codedeploy_install = "${var.install_codedeploy_agent ? "enabled" : "disabled"}"
   ssm_command_count  = 6
   ebs_device_map = {
-    amazon        = "/dev/sdf"
     amazon2       = "/dev/sdf"
     amazoneks     = "/dev/sdf"
     amazonecs     = "/dev/xvdcz"
@@ -225,7 +224,6 @@ EOF
     },
   ]
   user_data_map = {
-    amazon        = "amazon_linux_userdata.sh"
     amazon2       = "amazon_linux_userdata.sh"
     amazonecs     = "amazon_linux_userdata.sh"
     amazoneks     = "amazon_linux_userdata.sh"
@@ -241,7 +239,6 @@ EOF
     windows2019   = "windows_userdata.ps1"
   }
   ami_owner_mapping = {
-    amazon        = "137112412989"
     amazon2       = "137112412989"
     amazonecs     = "591542846629"
     amazoneks     = "602401143452"
@@ -257,7 +254,6 @@ EOF
     windows2019   = "801119661308"
   }
   ami_name_mapping = {
-    amazon        = "amzn-ami-hvm-2018.03.0.*gp2"
     amazon2       = "amzn2-ami-hvm-2.0.*-ebs"
     amazonecs     = "amzn2-ami-ecs-hvm-2*-x86_64-ebs"
     amazoneks     = "amazon-eks-node-*"
@@ -274,7 +270,6 @@ EOF
   }
   # Any custom AMI filters for a given OS can be added in this mapping
   image_filter = {
-    amazon        = []
     amazon2       = []
     amazonecs     = []
     amazoneks     = []

--- a/text/amazon_linux_userdata.sh
+++ b/text/amazon_linux_userdata.sh
@@ -20,11 +20,6 @@ else
         if [[ $ssm_running == "0" ]]; then
             systemctl start amazon-ssm-agent
         fi
-    else
-        # Amazon Linux
-        if [[ $ssm_running == "0" ]]; then
-            start amazon-ssm-agent
-        fi
     fi
 fi
 

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,7 @@ variable "detailed_monitoring" {
 }
 
 variable "ec2_os" {
-  description = "Intended Operating System/Distribution of Instance. Valid inputs are: `amazon`, `amazon2`, `amazoneks`, `amazonecs`, `rhel7`, `rhel8`, `centos7`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `ubuntu20`, `windows2012r2`, `windows2016`, `windows2019`"
+  description = "Intended Operating System/Distribution of Instance. Valid inputs are: `amazon2`, `amazoneks`, `amazonecs`, `rhel7`, `rhel8`, `centos7`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `ubuntu20`, `windows2012r2`, `windows2016`, `windows2019`"
   type        = "string"
 }
 


### PR DESCRIPTION
##### Corresponding Issue(s):
 - MPCSUPENG-2839
##### Summary of change(s):

Removing references to Amazon Linux for being EOL.

##### Reason for Change(s):

- Amazon Linux ended its standard support on December 31, 2020

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No. If you are using Amazon Linux then you should not upgrade to this version of the module.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

No.

##### If input variables or output variables have changed or has been added, have you updated the README?

Yes.

##### Do examples need to be updated based on changes?

No.

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.